### PR TITLE
use varcode's effects() helper to get handling of intergenic effects

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 from .allele_read import AlleleRead

--- a/isovar/effect_prediction.py
+++ b/isovar/effect_prediction.py
@@ -96,7 +96,7 @@ def predicted_effects_for_variant(
     if require_mutant_protein_sequence:
         effects_with_mut_sequence = [
             effect
-            for effect in nonsynonymous_coding_effects
+            for effect in effects
             if effect.mutant_protein_sequence is not None
         ]
         logger.info(
@@ -133,7 +133,8 @@ def top_varcode_effect(variant, transcript_id_whitelist=None):
 
 def reference_coding_transcripts_for_variant(
         variant,
-        transcript_id_whitelist=None):
+        transcript_id_whitelist=None,
+        drop_silent_and_noncoding=False):
     """
     For a given variant, find all the transcripts which overlap the
     variant and for which it has a predictable effect on the amino acid
@@ -143,7 +144,7 @@ def reference_coding_transcripts_for_variant(
         variant=variant,
         transcript_id_whitelist=transcript_id_whitelist,
         only_coding_transcripts=True,
-        drop_silent_and_noncoding=True,
+        drop_silent_and_noncoding=drop_silent_and_noncoding,
         require_mutant_protein_sequence=True)
     return [effect.transcript for effect in predicted_effects]
 

--- a/test/test_effect_prediction.py
+++ b/test/test_effect_prediction.py
@@ -1,0 +1,31 @@
+from isovar.effect_prediction import (
+    top_varcode_effect,
+    reference_coding_transcripts_for_variant
+)
+from varcode import Variant
+from varcode.effects import Intergenic
+from nose.tools import eq_
+
+# intergenic variant from error log of using Isovar 1.0.0
+intergenic_variant = Variant('1', 30256419, 'G', 'T', 'GRCh37')
+
+
+def test_top_effect_outside_of_gene():
+    top_effect = top_varcode_effect(intergenic_variant)
+    assert top_effect is not None
+    assert isinstance(top_effect, Intergenic)
+
+
+def test_reference_coding_transcripts_outside_of_gene():
+    transcripts_without_drop = \
+        reference_coding_transcripts_for_variant(
+            intergenic_variant,
+            drop_silent_and_noncoding=False)
+    eq_(len(transcripts_without_drop), 0)
+
+    transcripts_with_drop = \
+        reference_coding_transcripts_for_variant(
+            intergenic_variant,
+            drop_silent_and_noncoding=True)
+    eq_(len(transcripts_with_drop), 0)
+


### PR DESCRIPTION
`isovar.effect_prediction` appears to be duplicating some logic from `varcode.effects` for getting the effect of a variant on each overlapping transcript. Changing the code to use the Varcode helper, which also fixes dealing with intergenic variants. 

Bonus change: using `EffectCollection.clone_with_new_elements` to save metadata on effect collections during filter, seems more correct than silently switching from effect collections to lists. 