### PR TITLE
Only want IsovarResults with protein sequences that differ from reference to pass filters

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 
 from .allele_read import AlleleRead

--- a/isovar/effect_prediction.py
+++ b/isovar/effect_prediction.py
@@ -14,18 +14,24 @@
 
 from __future__ import print_function, division, absolute_import
 
-from varcode import EffectCollection
+from varcode.effects.effect_classes import ExonicSpliceSite, CodingMutation
 
 from .logging import get_logger
 
 logger = get_logger(__name__)
 
 
+def effect_in_coding_sequence(effect):
+    if type(effect) is ExonicSpliceSite:
+        return effect_in_coding_sequence(effect.alternate_effect)
+    else:
+        return isinstance(effect, CodingMutation)
+
 def predicted_effects_for_variant(
         variant,
         transcript_id_whitelist=None,
         only_coding_transcripts=False,
-        drop_silent_and_noncoding=False,
+        only_coding_effects=False,
         require_mutant_protein_sequence=False):
     """
     For a given variant, return its set of predicted effects. Optionally
@@ -42,9 +48,9 @@ def predicted_effects_for_variant(
     only_coding_transcripts : bool
         If True, then only return effects on protein coding transcripts
 
-    drop_silent_and_noncoding : bool
-        If True, drop effects which aren't predicted to change the protein
-        sequence.
+    only_coding_effects : bool
+        If True, drop effects which aren't in the coding sequence, even
+        if they are silent.
 
     require_mutant_protein_sequence : bool
         Drop effects for which we can't predict what the new protein sequence
@@ -53,6 +59,10 @@ def predicted_effects_for_variant(
     Returns a varcode.EffectCollection object
     """
     effects = variant.effects(raise_on_error=False)
+    n_total_effects = len(effects)
+    logger.info("Predicted total %d effects for variant %s" % (
+        n_total_effects,
+        variant))
 
     # effects filtered by allowed transcripts
     effects_filtered_by_transcript = []
@@ -60,11 +70,11 @@ def predicted_effects_for_variant(
     for effect in effects:
         has_transcript = hasattr(effect, 'transcript') and effect.transcript is not None
         transcript = getattr(effect, 'transcript', None)
-
-        if (only_coding_transcripts and not (
-                has_transcript and
-                transcript.complete and
-                transcript.is_protein_coding)):
+        transcript_is_coding = (
+            has_transcript and
+            transcript.complete and
+            transcript.is_protein_coding)
+        if only_coding_transcripts and not transcript_is_coding:
             continue
         elif transcript_id_whitelist and not has_transcript:
             continue
@@ -77,21 +87,23 @@ def predicted_effects_for_variant(
         effects_filtered_by_transcript.append(effect)
 
     effects = effects.clone_with_new_elements(effects_filtered_by_transcript)
-
-    n_total_effects = len(effects)
-    logger.info("Predicted total %d effects for variant %s" % (
+    logger.info(
+        "Keeping %d/%d effects which have associated coding transcripts for %s: %s",
+        len(effects),
         n_total_effects,
-        variant))
+        variant,
+        effects)
 
-    if drop_silent_and_noncoding:
-        nonsynonymous_coding_effects = effects.drop_silent_and_noncoding()
+    if only_coding_effects:
+        effects = effects.clone_with_new_elements([
+            e for e in effects if effect_in_coding_sequence(e)
+        ])
         logger.info(
-            "Keeping %d/%d effects which affect protein coding sequence for %s: %s",
-            len(nonsynonymous_coding_effects),
+            "Keeping %d/%d effects in coding sequence for %s: %s",
+            len(effects),
             n_total_effects,
             variant,
-            nonsynonymous_coding_effects)
-        effects = nonsynonymous_coding_effects
+            effects)
 
     if require_mutant_protein_sequence:
         effects_with_mut_sequence = [
@@ -134,17 +146,26 @@ def top_varcode_effect(variant, transcript_id_whitelist=None):
 def reference_coding_transcripts_for_variant(
         variant,
         transcript_id_whitelist=None,
-        drop_silent_and_noncoding=False):
+        only_coding_effects=True):
     """
     For a given variant, find all the transcripts which overlap the
     variant and for which it has a predictable effect on the amino acid
     sequence of the protein.
+
+    Parameters
+    ----------
+    variant : varcode.Variant
+
+    transcript_id_whitelist : set or None
+
+    only_coding_effects : bool
+        Exclude non-coding effects such as intronic
     """
     predicted_effects = predicted_effects_for_variant(
         variant=variant,
         transcript_id_whitelist=transcript_id_whitelist,
         only_coding_transcripts=True,
-        drop_silent_and_noncoding=drop_silent_and_noncoding,
-        require_mutant_protein_sequence=True)
+        only_coding_effects=True,
+        require_mutant_protein_sequence=False)
     return [effect.transcript for effect in predicted_effects]
 

--- a/isovar/filtering.py
+++ b/isovar/filtering.py
@@ -92,7 +92,9 @@ def evaluate_boolean_filters(isovar_result, filter_flags):
         else:
             raise ValueError(
                 "IsovarResult does not have field name '%s'" % boolean_field_name)
-        if field_value not in {True, False}:
+        if field_value is None:
+            field_value = False
+        elif field_value not in {True, False}:
             raise ValueError("Expected filter '%s' to be boolean but got %s" % (
                 boolean_filter_name,
                 field_value))

--- a/isovar/isovar_result.py
+++ b/isovar/isovar_result.py
@@ -140,6 +140,8 @@ class IsovarResult(object):
 
         d["predicted_effect"] = effect.short_description
         d["predicted_effect_class"] = effect.__class__.__name__
+        d["predicted_effect_modifies_protein_sequence"] = \
+            self.predicted_effect_modifies_protein_sequence
 
         # list of field names on varcode effect properties
         effect_properties = [
@@ -170,8 +172,6 @@ class IsovarResult(object):
         # paired with names of fields on ProteinSequence
         protein_sequence_properties = [
             ("protein_sequence", "amino_acids"),
-            ("protein_sequence_mutation_start", "variant_aa_interval_start"),
-            ("protein_sequence_mutation_end", "variant_aa_interval_stop"),
             ("protein_sequence_ends_with_stop_codon", "ends_with_stop_codon"),
             ("protein_sequence_gene_names", "gene_names"),
             ("protein_sequence_gene_ids", "gene_ids"),
@@ -183,11 +183,13 @@ class IsovarResult(object):
             if isinstance(value, (list, set, tuple)):
                 value = ";".join(value)
             d[name] = value
+        d["protein_sequence_mutation_start"] = self.protein_sequence_mutation_start
+        d["protein_sequence_mutation_end"] = self.protein_sequence_mutation_end
 
         d["trimmed_predicted_mutant_protein_sequence"] = self.trimmed_predicted_mutant_protein_sequence
         d["trimmed_reference_protein_sequence"] = self.trimmed_reference_protein_sequence
         d["protein_sequence_contains_mutation"] = self.protein_sequence_contains_mutation
-        d["protein_sequence_matches_predicted_effect"] = self.protein_sequence_matches_predicted_effect
+        d["protein_sequence_matches_predicted_mutation_effect"] = self.protein_sequence_matches_predicted_mutation_effect
 
         ########################################################################
         # filters
@@ -225,6 +227,47 @@ class IsovarResult(object):
             return self.sorted_protein_sequences[0]
         else:
             return None
+
+    @cached_property
+    def protein_sequence_mutation_start(self):
+        """
+        Interbase start coordinate for mutated amino acids in top protein
+        sequence.
+
+        Returns
+        -------
+        int or None
+        """
+        if self.has_mutant_protein_sequence_from_rna:
+            return self.top_protein_sequence.variant_aa_interval_start
+        else:
+            return None
+
+    @cached_property
+    def protein_sequence_mutation_end(self):
+        """
+        Interbase end coordinate for mutated amino acids in top protein
+        sequence.
+
+        Returns
+        -------
+        int or None
+        """
+        if self.has_mutant_protein_sequence_from_rna:
+            return self.top_protein_sequence.variant_aa_interval_stop
+        else:
+            return None
+
+    @cached_property
+    def predicted_effect_modifies_protein_sequence(self):
+        """
+        Does the predicted effect change the protein sequence?
+
+        Returns bool
+        """
+        if self.predicted_effect is None:
+            return None
+        return self.predicted_effect.modifies_protein_sequence
 
     @cached_property
     def num_cdna_mismatches_in_top_protein_sequence(self):
@@ -421,7 +464,7 @@ class IsovarResult(object):
             predicted_sequence)
 
     @cached_property
-    def protein_sequence_matches_predicted_effect(self):
+    def protein_sequence_matches_predicted_mutation_effect(self):
         """
         Does the top protein sequence translated from RNA reads
         match the predicted protein change determined by Varcode?
@@ -456,14 +499,44 @@ class IsovarResult(object):
             original_sequence)
 
     @cached_property
-    def protein_sequence_contains_mutation(self):
+    def protein_sequence_matches_reference(self):
+        """
+        Does the top protein sequence translated from RNA reads
+        match the reference protein sequence?
+
+        Returns bool
+        """
+        return self.num_amino_acid_mismatches_from_reference == 0
+
+    @cached_property
+    def protein_sequence_different_from_reference(self):
         """
         Does the top protein sequence translated from RNA reads
         differ from the reference?
 
         Returns bool
         """
-        return self.num_amino_acid_mismatches_from_reference == 0
+        return not self.protein_sequence_matches_reference
+
+    @cached_property
+    def protein_sequence_contains_mutation(self):
+        """
+        Does the protein sequence assembled from RNA contain a mutation?
+
+        Returns bool
+        """
+        # if the sequence is the same as the reference then the genomic
+        # variant must have been silent, or maybe was made silent by adjacent
+        # phased variants.
+        if self.protein_sequence_matches_reference:
+            return False
+
+        start_idx  = self.protein_sequence_mutation_start
+        stop_idx = self.protein_sequence_mutation_end
+
+        if start_idx is None or stop_idx is None:
+            return False
+        return start_idx != stop_idx or self.variant.is_deletion
 
     @cached_property
     def num_protein_sequences(self):

--- a/isovar/isovar_result.py
+++ b/isovar/isovar_result.py
@@ -196,7 +196,7 @@ class IsovarResult(object):
         ########################################################################
         for filter_name, filter_value in self.filter_values.items():
             d["filter:%s" % filter_name] = filter_value
-        d["passes_all_filters"] = self.passes_all_filters
+        d["pass"] = d["passes_all_filters"] = self.passes_all_filters
 
         return d
 

--- a/isovar/main.py
+++ b/isovar/main.py
@@ -69,8 +69,9 @@ DEFAULT_FILTER_THRESHOLDS =  OrderedDict([
 ])
 
 DEFAULT_FILTER_FLAGS = [
+    "predicted_effect_modifies_protein_sequence",
+    "has_mutant_protein_sequence_from_rna",
     "protein_sequence_contains_mutation",
-    "predicted_effect_modifies_protein_sequence"
 ]
 
 def run_isovar(

--- a/isovar/main.py
+++ b/isovar/main.py
@@ -68,6 +68,7 @@ DEFAULT_FILTER_THRESHOLDS =  OrderedDict([
     ("min_ratio_alt_to_other_fragments", MIN_RATIO_RNA_ALT_TO_OTHER_FRAGMENTS)
 ])
 
+DEFAULT_FILTER_FLAGS = ["protein_sequence_contains_mutation"]
 
 def run_isovar(
         variants,
@@ -76,7 +77,7 @@ def run_isovar(
         read_collector=None,
         protein_sequence_creator=None,
         filter_thresholds=DEFAULT_FILTER_THRESHOLDS,
-        filter_flags=[]):
+        filter_flags=DEFAULT_FILTER_FLAGS):
     """
     This is the main entrypoint into the Isovar library, which collects
     RNA reads supporting variants and translates their coding sequence

--- a/isovar/main.py
+++ b/isovar/main.py
@@ -68,7 +68,10 @@ DEFAULT_FILTER_THRESHOLDS =  OrderedDict([
     ("min_ratio_alt_to_other_fragments", MIN_RATIO_RNA_ALT_TO_OTHER_FRAGMENTS)
 ])
 
-DEFAULT_FILTER_FLAGS = ["protein_sequence_contains_mutation"]
+DEFAULT_FILTER_FLAGS = [
+    "protein_sequence_contains_mutation",
+    "predicted_effect_modifies_protein_sequence"
+]
 
 def run_isovar(
         variants,

--- a/isovar/protein_sequence_creator.py
+++ b/isovar/protein_sequence_creator.py
@@ -152,9 +152,10 @@ class ProteinSequenceCreator(ValueObject):
             cdna_variant_start_offset = variant_orf.variant_cdna_interval_start
             cdna_variant_end_offset = variant_orf.variant_cdna_interval_end
 
-            # TODO: determine if the first codon is the start codon of a
-            # transcript, for now any of the unusual start codons like CTG
-            # will translate to leucine instead of methionine.
+            # TODO:
+            #  determine if the first codon is the start codon of a
+            #  transcript, for now any of the unusual start codons like CTG
+            #  will translate to leucine instead of methionine.
             variant_amino_acids, ends_with_stop_codon = translate_cdna(
                 cdna_sequence[cdna_codon_offset:],
                 first_codon_is_start=False,

--- a/isovar/read_collector.py
+++ b/isovar/read_collector.py
@@ -209,14 +209,8 @@ class ReadCollector(object):
                 reference_position_after_insertion)
 
             if read_base0_before_insertion is None:
-                logger.warning("Cannot use read '%s' because reference position %d is not mapped" % (
-                    name,
-                    reference_position_before_insertion))
                 return None
             elif read_base0_after_insertion is None:
-                logger.warning("Cannot use read '%s' because reference position %d is not mapped" % (
-                    name,
-                    reference_position_after_insertion))
                 return None
             elif read_base0_after_insertion - read_base0_after_insertion == 1:
                 read_base0_start_inclusive = read_base0_end_exclusive = read_base0_before_insertion + 1
@@ -254,16 +248,11 @@ class ReadCollector(object):
                         reference_base0_position_before_locus]
                     read_base0_start_inclusive = read_base0_position_before_locus + 1
                 else:
-                    logger.warning(
-                        "Cannot use read '%s' because neither reference positions %d or %d are mapped" % (
-                            name,
-                            base0_start_inclusive,
-                            reference_base0_position_before_locus))
                     return None
 
             read_base0_end_exclusive = base0_reference_positions_dict.get(base0_end_exclusive)
             if read_base0_end_exclusive is None:
-                # if exclusve last index of reference interval doesn't have a corresponding
+                # if exclusive last index of reference interval doesn't have a corresponding
                 # base position then try getting the base position of the reference
                 # position before it and then adding one
                 reference_base0_end_inclusive = base0_end_exclusive - 1
@@ -272,11 +261,6 @@ class ReadCollector(object):
                         reference_base0_end_inclusive]
                     read_base0_end_exclusive = read_base0_end_inclusive + 1
                 else:
-                    logger.warning(
-                        "Cannot use read '%s' because neither reference positions %d or %d are mapped" % (
-                            name,
-                            base0_end_exclusive,
-                            reference_base0_end_inclusive))
                     return None
 
 

--- a/isovar/reference_context.py
+++ b/isovar/reference_context.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
-from collections import OrderedDict, defaultdict
-
 
 from .reference_coding_sequence_key import ReferenceCodingSequenceKey
 from .logging import get_logger

--- a/isovar/reference_context_helpers.py
+++ b/isovar/reference_context_helpers.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 
 from .effect_prediction import reference_coding_transcripts_for_variant

--- a/test/test_effect_prediction.py
+++ b/test/test_effect_prediction.py
@@ -20,12 +20,12 @@ def test_reference_coding_transcripts_outside_of_gene():
     transcripts_without_drop = \
         reference_coding_transcripts_for_variant(
             intergenic_variant,
-            drop_silent_and_noncoding=False)
+            only_coding_effects=False)
     eq_(len(transcripts_without_drop), 0)
 
     transcripts_with_drop = \
         reference_coding_transcripts_for_variant(
             intergenic_variant,
-            drop_silent_and_noncoding=True)
+            only_coding_effects=True)
     eq_(len(transcripts_with_drop), 0)
 

--- a/test/test_isovar_result.py
+++ b/test/test_isovar_result.py
@@ -3,6 +3,8 @@ from isovar import ProteinSequence
 from varcode import Variant
 from testing_helpers import data_path
 
+from nose.tools import eq_
+
 
 def test_isovar_result_property_types():
     for result in run_isovar(
@@ -54,3 +56,25 @@ def test_isovar_result_property_types():
         # this property aggregates all filters
         assert result.passes_all_filters in {True, False}
 
+        assert type(result.protein_sequence_mutation_start) in (int, type(None))
+        assert type(result.protein_sequence_mutation_end) in (int, type(None))
+
+
+def test_isovar_result_nonsyn_variants():
+    for result in run_isovar(
+            variants=data_path("data/b16.f10/b16.vcf"),
+            alignment_file=data_path("data/b16.f10/b16.combined.sorted.bam")):
+        print(result.variant)
+        print(result.predicted_effect)
+        if result.has_mutant_protein_sequence_from_rna:
+            assert result.num_amino_acid_mismatches_from_predicted_effect is not None
+            assert result.num_amino_acid_mismatches_from_reference is not None
+            assert result.num_amino_acid_mismatches_from_reference > 0
+            eq_(result.protein_sequence_matches_reference, False)
+            eq_(result.protein_sequence_contains_mutation, True)
+        else:
+            assert result.num_amino_acid_mismatches_from_predicted_effect is None
+            assert result.num_amino_acid_mismatches_from_reference is None
+            assert result.protein_sequence_matches_predicted_mutation_effect is None
+            assert result.protein_sequence_matches_reference is None
+            assert result.protein_sequence_contains_mutation is None


### PR DESCRIPTION
Added boolean property `protein_sequence_contains_mutation` and several helper properties to use for filtering. Also made the default filter flags:

```
[
    "predicted_effect_modifies_protein_sequence",
    "has_mutant_protein_sequence_from_rna",
    "protein_sequence_contains_mutation",
]
```

...since I was otherwise getting non-coding effects and isovar results without RNA coverage in the passing set. 