### PR TITLE
Exit early if no reference contexts for variant

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 
 from .allele_read import AlleleRead

--- a/isovar/cli/protein_sequence_args.py
+++ b/isovar/cli/protein_sequence_args.py
@@ -50,7 +50,7 @@ def protein_sequence_creator_from_args(args):
         max_transcript_mismatches=args.max_reference_transcript_mismatches,
         max_protein_sequences_per_variant=args.max_protein_sequences_per_variant,
         variant_sequence_assembly=args.variant_sequence_assembly,
-        reference_context_size=args.context_size)
+        reference_context_size=args.reference_context_size)
 
 
 def make_protein_sequences_arg_parser(**kwargs):

--- a/isovar/cli/protein_sequence_args.py
+++ b/isovar/cli/protein_sequence_args.py
@@ -49,7 +49,8 @@ def protein_sequence_creator_from_args(args):
         min_transcript_prefix_length=args.min_transcript_prefix_length,
         max_transcript_mismatches=args.max_reference_transcript_mismatches,
         max_protein_sequences_per_variant=args.max_protein_sequences_per_variant,
-        variant_sequence_assembly=args.variant_sequence_assembly)
+        variant_sequence_assembly=args.variant_sequence_assembly,
+        reference_context_size=args.context_size)
 
 
 def make_protein_sequences_arg_parser(**kwargs):

--- a/isovar/cli/reference_context_args.py
+++ b/isovar/cli/reference_context_args.py
@@ -31,7 +31,7 @@ def add_reference_context_args(parser):
     """
     reference_context_group = parser.add_argument_group("Reference Transcripts")
     parser.add_argument(
-        "--context-size",
+        "--reference-context-size",
         default=CDNA_CONTEXT_SIZE,
         type=int)
     return reference_context_group
@@ -62,5 +62,5 @@ def reference_contexts_dataframe_from_args(args):
     variants = variant_collection_from_args(args)
     reference_context_gen = reference_contexts_generator(
         variants=variants,
-        context_size=args.context_size)
+        context_size=args.reference_context_size)
     return variants_to_reference_contexts_dataframe(reference_context_gen)

--- a/isovar/cli/translation_args.py
+++ b/isovar/cli/translation_args.py
@@ -26,7 +26,7 @@ from ..default_parameters import (
     PROTEIN_SEQUENCE_LENGTH,
 )
 from .variant_sequences_args import make_variant_sequences_arg_parser
-
+from .reference_context_args import add_reference_context_args
 
 def add_translation_args(parser):
     translation_group = parser.add_argument_group(
@@ -79,5 +79,6 @@ def make_translation_arg_parser(**kwargs):
     in this module.
     """
     parser = make_variant_sequences_arg_parser(**kwargs)
+    add_reference_context_args(parser)
     add_translation_args(parser)
     return parser


### PR DESCRIPTION
Using the CLI `reference-context-size` argument to determine how many nucleotides to use to match assembled sequences vs. reference transcripts. This allows us to skip assembly at locations for which no reference contexts can be determined.