### PR TITLE
use list.index instead of dictionary construction to speed up LocusRead construction

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 
 from .allele_read import AlleleRead

--- a/isovar/cli/isovar_main.py
+++ b/isovar/cli/isovar_main.py
@@ -26,7 +26,6 @@ import sys
 from ..logging import get_logger
 from ..dataframe_helpers import isovar_results_to_dataframe
 
-
 from .main_args import run_isovar_from_parsed_args, make_isovar_arg_parser
 
 from .output_args import add_output_args, write_dataframe

--- a/isovar/cli/reference_context_args.py
+++ b/isovar/cli/reference_context_args.py
@@ -30,7 +30,7 @@ def add_reference_context_args(parser):
         --context-size
     """
     reference_context_group = parser.add_argument_group("Reference Transcripts")
-    parser.add_argument(
+    reference_context_group.add_argument(
         "--reference-context-size",
         default=CDNA_CONTEXT_SIZE,
         type=int)

--- a/isovar/cli/rna_args.py
+++ b/isovar/cli/rna_args.py
@@ -19,6 +19,7 @@ Common command-line arguments for all Isovar commands which use RNA
 from __future__ import print_function, division, absolute_import
 
 from pysam import AlignmentFile
+from psutil import cpu_count
 
 from varcode.cli import make_variants_parser, variant_collection_from_args
 
@@ -66,6 +67,11 @@ def add_rna_args(
             "By default, secondary alignments are included in reads, "
             "use this option to instead only use primary alignments."))
 
+    rna_group.add_argument(
+        "--num-rna-decompression-threads",
+        help="Number of threads to use for decompression of BAM/CRAM files",
+        default=cpu_count())
+
     return rna_group
 
 
@@ -88,7 +94,9 @@ def alignment_file_from_args(args):
     """
     Use parsed arguments to load a file of aligned RNA reads.
     """
-    return AlignmentFile(args.bam)
+    return AlignmentFile(
+        args.bam,
+        threads=args.num_rna_decompression_threads)
 
 
 def read_collector_from_args(args):

--- a/isovar/cli/rna_args.py
+++ b/isovar/cli/rna_args.py
@@ -113,7 +113,6 @@ def read_evidence_generator_from_args(args):
         variants=variants,
         alignment_file=samfile)
 
-
 def variant_reads_generator_from_args(args):
     """
     Creates a generator of (Variant, list of AlleleRead) from parsed

--- a/isovar/main.py
+++ b/isovar/main.py
@@ -42,7 +42,7 @@ from .default_parameters import (
 )
 from .effect_prediction import top_varcode_effect
 from .filtering import apply_filters
-from .phasing import find_phased_variants
+from .phasing import annotate_phased_variants
 
 logger = get_logger(__name__)
 
@@ -84,7 +84,8 @@ def run_isovar(
         protein_sequence_creator=None,
         filter_thresholds=DEFAULT_FILTER_THRESHOLDS,
         filter_flags=DEFAULT_FILTER_FLAGS,
-        min_shared_fragments_for_phasing=MIN_SHARED_FRAGMENTS_FOR_PHASING):
+        min_shared_fragments_for_phasing=MIN_SHARED_FRAGMENTS_FOR_PHASING,
+        decompress_threads=1):
     """
     This is the main entrypoint into the Isovar library, which collects
     RNA reads supporting variants and translates their coding sequence
@@ -126,6 +127,10 @@ def run_isovar(
         they can also be negated by prepending "not_",
         such as "not_has_protein_sequence".
 
+    decompress_threads : int
+        Number of threads used by htslib to decompress BAM/CRAM
+        files.
+
     Generator of IsovarResult objects, one for each variant. The
     `protein_sequences` field of the IsovarVar result will be empty
     if no sequences could be determined.
@@ -134,7 +139,9 @@ def run_isovar(
         variants = load_vcf(variants)
 
     if isinstance(alignment_file, string_types):
-        alignment_file = AlignmentFile(alignment_file)
+        alignment_file = AlignmentFile(
+            alignment_file,
+            threads=decompress_threads)
 
     if read_collector is None:
         read_collector = ReadCollector()
@@ -169,5 +176,7 @@ def run_isovar(
             filter_thresholds=filter_thresholds,
             filter_flags=filter_flags)
         results.append(isovar_result)
-    results = find_phased_variants(results)
+    results = annotate_phased_variants(
+        results,
+        min_shared_fragments_for_phasing)
     return results

--- a/isovar/main.py
+++ b/isovar/main.py
@@ -19,6 +19,7 @@ from six import string_types
 from varcode import load_vcf
 from pysam import AlignmentFile
 from collections import OrderedDict
+from psutil import cpu_count
 
 from .protein_sequence_creator import ProteinSequenceCreator
 from .read_collector import ReadCollector
@@ -85,7 +86,7 @@ def run_isovar(
         filter_thresholds=DEFAULT_FILTER_THRESHOLDS,
         filter_flags=DEFAULT_FILTER_FLAGS,
         min_shared_fragments_for_phasing=MIN_SHARED_FRAGMENTS_FOR_PHASING,
-        decompress_threads=1):
+        decompression_threads=cpu_count()):
     """
     This is the main entrypoint into the Isovar library, which collects
     RNA reads supporting variants and translates their coding sequence
@@ -141,7 +142,7 @@ def run_isovar(
     if isinstance(alignment_file, string_types):
         alignment_file = AlignmentFile(
             alignment_file,
-            threads=decompress_threads)
+            threads=decompression_threads)
 
     if read_collector is None:
         read_collector = ReadCollector()

--- a/isovar/phasing.py
+++ b/isovar/phasing.py
@@ -19,7 +19,7 @@ from collections import defaultdict, Counter
 from .default_parameters import MIN_SHARED_FRAGMENTS_FOR_PHASING
 
 
-def find_phased_variants(
+def annotate_phased_variants(
         unphased_isovar_results,
         min_shared_fragments_for_phasing=MIN_SHARED_FRAGMENTS_FOR_PHASING):
     """

--- a/isovar/read_collector.py
+++ b/isovar/read_collector.py
@@ -85,31 +85,24 @@ class ReadCollector(object):
         -------
         LocusRead or None
         """
-        if not isinstance(base0_start_inclusive, integer_types):
-            raise TypeError("Expected base0_start_inclusive to be an integer but got %s" % (
-                type(base0_start_inclusive),))
-        if not isinstance(base0_end_exclusive, integer_types):
-            raise TypeError("Expected base0_end_exclusive to be an integer but got %s" % (
-                type(base0_end_exclusive),))
-
-        name = pysam_aligned_segment.query_name
-        if name is None:
-            logger.warn(
-                "Read missing name at position %d",
-                base0_start_inclusive + 1)
+        if pysam_aligned_segment.is_secondary and not self.use_secondary_alignments:
             return None
+
+        if pysam_aligned_segment.is_duplicate and not self.use_duplicate_reads:
+            return None
+
 
         if pysam_aligned_segment.is_unmapped:
             logger.warn(
                 "How did we get unmapped read '%s' in a pileup?", name)
             return None
 
-        if pysam_aligned_segment.is_secondary and not self.use_secondary_alignments:
-            logger.debug("Skipping secondary alignment of read '%s'", name)
-            return None
+        name = pysam_aligned_segment.query_name
 
-        if pysam_aligned_segment.is_duplicate and not self.use_duplicate_reads:
-            logger.debug("Skipping duplicate read '%s'", name)
+        if name is None:
+            logger.warn(
+                "Read missing name at position %d",
+                base0_start_inclusive + 1)
             return None
 
         mapping_quality = pysam_aligned_segment.mapping_quality
@@ -126,6 +119,7 @@ class ReadCollector(object):
             return None
 
         sequence = pysam_aligned_segment.query_sequence
+
         if sequence is None:
             logger.warn("Skipping read '%s' due to missing sequence" % name)
             return None
@@ -148,7 +142,8 @@ class ReadCollector(object):
         # within the read. The returned list will thus be of the same
         # length as the read.
 
-        base0_reference_positions = pysam_aligned_segment.get_reference_positions(full_length=True)
+        base0_reference_positions = \
+            pysam_aligned_segment.get_reference_positions(full_length=True)
 
         if len(base0_reference_positions) != len(base_qualities):
             logger.warn(
@@ -158,20 +153,14 @@ class ReadCollector(object):
                     len(base_qualities)))
             return None
 
-        base0_reference_positions_dict = {
-            base0_reference_pos: base0_read_pos
-            for (base0_read_pos, base0_reference_pos)
-            in enumerate(base0_reference_positions)
-            if base0_reference_pos is not None
-        }
-
         reference_interval_size = base0_end_exclusive - base0_start_inclusive
         if reference_interval_size < 0:
             raise ValueError("Unexpected interval start after interval end")
 
-        # TODO: Consider how to handle variants before splice sites, where
-        # the bases before or after on the genome will not be mapped on the
-        # read
+        # TODO:
+        #  Consider how to handle variants before splice sites, where
+        #  the bases before or after on the genome will not be mapped on the
+        #  read
         #
         # we have a dictionary mapping base-1 reference positions to base-0
         # read indices and we need to use that to convert the reference
@@ -203,16 +192,20 @@ class ReadCollector(object):
             # going to allow the start/end to be None.
             reference_position_before_insertion = base0_start_inclusive - 1
             reference_position_after_insertion = base0_start_inclusive
-            read_base0_before_insertion = base0_reference_positions_dict.get(
-                reference_position_before_insertion)
-            read_base0_after_insertion = base0_reference_positions_dict.get(
-                reference_position_after_insertion)
+            if reference_position_before_insertion in base0_reference_positions:
+                read_base0_before_insertion = \
+                    base0_reference_positions.index(
+                        reference_position_before_insertion)
+            else:
+                return None
 
-            if read_base0_before_insertion is None:
+            if reference_position_after_insertion in base0_reference_positions:
+                read_base0_after_insertion = base0_reference_positions.index(
+                    reference_position_after_insertion)
+            else:
                 return None
-            elif read_base0_after_insertion is None:
-                return None
-            elif read_base0_after_insertion - read_base0_after_insertion == 1:
+
+            if read_base0_after_insertion - read_base0_after_insertion == 1:
                 read_base0_start_inclusive = read_base0_end_exclusive = read_base0_before_insertion + 1
             else:
                 read_base0_start_inclusive = read_base0_before_insertion + 1
@@ -238,31 +231,29 @@ class ReadCollector(object):
             # figure out which read indices correspond to base0_start_inclusive and
             # base0_end_exclusive but this would fail if base0_end_exclusive is
             # after the end the end of the read.
-            read_base0_start_inclusive = base0_reference_positions_dict.get(base0_start_inclusive)
-            if read_base0_start_inclusive is None:
+            if base0_start_inclusive in base0_reference_positions:
+                read_base0_start_inclusive = base0_reference_positions.index(base0_start_inclusive)
+            elif base0_start_inclusive - 1 in base0_reference_positions:
                 # if first base of reference locus isn't mapped, try getting the base
                 # before it and then adding one to its corresponding base index
-                reference_base0_position_before_locus = base0_start_inclusive - 1
-                if reference_base0_position_before_locus in base0_reference_positions_dict:
-                    read_base0_position_before_locus = base0_reference_positions_dict[
-                        reference_base0_position_before_locus]
-                    read_base0_start_inclusive = read_base0_position_before_locus + 1
-                else:
-                    return None
+                read_base0_position_before_locus = \
+                    base0_reference_positions.index(base0_start_inclusive - 1)
+                read_base0_start_inclusive = read_base0_position_before_locus + 1
+            else:
+                return None
 
-            read_base0_end_exclusive = base0_reference_positions_dict.get(base0_end_exclusive)
-            if read_base0_end_exclusive is None:
+            if base0_end_exclusive in base0_reference_positions:
+                read_base0_end_exclusive = \
+                    base0_reference_positions.index(base0_end_exclusive)
+            elif (base0_end_exclusive - 1) in base0_reference_positions:
                 # if exclusive last index of reference interval doesn't have a corresponding
                 # base position then try getting the base position of the reference
                 # position before it and then adding one
-                reference_base0_end_inclusive = base0_end_exclusive - 1
-                if reference_base0_end_inclusive in base0_reference_positions_dict:
-                    read_base0_end_inclusive = base0_reference_positions_dict[
-                        reference_base0_end_inclusive]
-                    read_base0_end_exclusive = read_base0_end_inclusive + 1
-                else:
-                    return None
-
+                read_base0_end_inclusive = \
+                    base0_reference_positions.index(base0_end_exclusive - 1)
+                read_base0_end_exclusive = read_base0_end_inclusive + 1
+            else:
+                return None
 
         if isinstance(sequence, bytes):
             sequence = sequence.decode('ascii')

--- a/isovar/read_collector.py
+++ b/isovar/read_collector.py
@@ -91,18 +91,17 @@ class ReadCollector(object):
         if pysam_aligned_segment.is_duplicate and not self.use_duplicate_reads:
             return None
 
-
-        if pysam_aligned_segment.is_unmapped:
-            logger.warn(
-                "How did we get unmapped read '%s' in a pileup?", name)
-            return None
-
         name = pysam_aligned_segment.query_name
 
         if name is None:
             logger.warn(
                 "Read missing name at position %d",
                 base0_start_inclusive + 1)
+            return None
+
+        if pysam_aligned_segment.is_unmapped:
+            logger.warn(
+                "How did we get unmapped read '%s' in a pileup?", name)
             return None
 
         mapping_quality = pysam_aligned_segment.mapping_quality

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas>=0.23.0
 pysam>=0.15.2,<=0.16.0
 nose>=1.3.3
 cached_property>=1.5.1
+psutil

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ if __name__ == '__main__':
             'varcode>=0.9.0',
             'pyensembl>=1.5.0',
             'cached_property>=1.5.1',
+            'psutil',
         ],
         long_description=readme_markdown,
         long_description_content_type='text/markdown',


### PR DESCRIPTION
Before PR: 181s

PR (list instead of dict in LocusRead construction): 58s

PR (+multithreaded decompression of BAM): 40s