### PR TITLE
Fix mismatch count after variant

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 
 from .allele_read import AlleleRead

--- a/isovar/cli/protein_sequence_args.py
+++ b/isovar/cli/protein_sequence_args.py
@@ -49,8 +49,7 @@ def protein_sequence_creator_from_args(args):
         min_transcript_prefix_length=args.min_transcript_prefix_length,
         max_transcript_mismatches=args.max_reference_transcript_mismatches,
         max_protein_sequences_per_variant=args.max_protein_sequences_per_variant,
-        variant_sequence_assembly=args.variant_sequence_assembly,
-        reference_context_size=args.reference_context_size)
+        variant_sequence_assembly=args.variant_sequence_assembly)
 
 
 def make_protein_sequences_arg_parser(**kwargs):

--- a/isovar/cli/reference_context_args.py
+++ b/isovar/cli/reference_context_args.py
@@ -20,7 +20,6 @@ from varcode.cli.variant_args import (
 )
 
 from ..reference_context_helpers import reference_contexts_generator
-from ..default_parameters import CDNA_CONTEXT_SIZE
 from ..dataframe_helpers import variants_to_reference_contexts_dataframe
 
 
@@ -33,7 +32,7 @@ def add_reference_context_args(parser):
     reference_context_group.add_argument(
         "--reference-context-size",
         type=int,
-        default=CDNA_CONTEXT_SIZE,
+        default=30,
         help=(
             "Number of nucleotides used to match assembled sequence to "
             "reference transcript to establish reading frame."))

--- a/isovar/default_parameters.py
+++ b/isovar/default_parameters.py
@@ -51,11 +51,6 @@ USE_SECONDARY_ALIGNMENTS = True
 # number of nucleotides to extract from RNAseq reads around each variant
 VARIANT_SEQUENCE_LENGTH = 90
 
-# number of nucleotides to the left and right of a variant to extract,
-# usually gets adjusted for variant length but some functions take this
-# parameter directly
-CDNA_CONTEXT_SIZE = 25
-
 # minimum number of reads supporting each nucleotide of a
 # variant coding sequence
 MIN_VARIANT_SEQUENCE_COVERAGE = 2

--- a/isovar/protein_sequence_creator.py
+++ b/isovar/protein_sequence_creator.py
@@ -264,7 +264,9 @@ class ProteinSequenceCreator(ValueObject):
 
         reference_contexts = reference_contexts_for_variant(
             variant,
-            context_size=self.reference_context_size,
+            context_size=min(
+                self.reference_context_size,
+                self._cdna_sequence_length // 2 - 1),
             transcript_id_whitelist=transcript_id_whitelist)
 
         if len(reference_contexts) == 0:

--- a/isovar/protein_sequence_creator.py
+++ b/isovar/protein_sequence_creator.py
@@ -24,7 +24,6 @@ from .default_parameters import (
     MIN_VARIANT_SEQUENCE_COVERAGE,
     VARIANT_SEQUENCE_ASSEMBLY,
     MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE,
-    CDNA_CONTEXT_SIZE,
 )
 
 from .genetic_code import translate_cdna
@@ -62,8 +61,7 @@ class ProteinSequenceCreator(ValueObject):
             count_mismatches_after_variant=COUNT_MISMATCHES_AFTER_VARIANT,
             max_protein_sequences_per_variant=MAX_PROTEIN_SEQUENCES_PER_VARIANT,
             variant_sequence_assembly=VARIANT_SEQUENCE_ASSEMBLY,
-            min_assembly_overlap_size=MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE,
-            reference_context_size=CDNA_CONTEXT_SIZE):
+            min_assembly_overlap_size=MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE):
         """
         protein_sequence_length : int
             Try to translate protein sequences of this length, though sometimes
@@ -97,10 +95,6 @@ class ProteinSequenceCreator(ValueObject):
         min_assembly_overlap_size : int
             Minimum number of nucleotides that two reads need to overlap before they
             can be merged into a single coding sequence.
-
-        reference_context_size : int
-            Number of nucleotides before variant to use to match assembled
-            coding sequences to reference transcripts.
         """
         self.protein_sequence_length = protein_sequence_length
         self.min_variant_sequence_coverage = min_variant_sequence_coverage
@@ -109,7 +103,6 @@ class ProteinSequenceCreator(ValueObject):
         self.count_mismatches_after_variant = count_mismatches_after_variant
         self.variant_sequence_assembly = variant_sequence_assembly
         self.min_assembly_overlap_size = min_assembly_overlap_size
-        self.reference_context_size = reference_context_size
 
         # Adding an extra codon to the desired RNA sequence length in case we
         # need to clip nucleotides at the start/end of the sequence
@@ -292,9 +285,7 @@ class ProteinSequenceCreator(ValueObject):
 
         reference_contexts = reference_contexts_for_variant(
             variant,
-            context_size=max(
-                self.reference_context_size,
-                self._cdna_sequence_length),
+            context_size=self._cdna_sequence_length,
             transcript_id_whitelist=transcript_id_whitelist)
 
         if len(reference_contexts) == 0:

--- a/isovar/variant_orf.py
+++ b/isovar/variant_orf.py
@@ -177,7 +177,7 @@ def trim_sequences(variant_sequence, reference_context):
            same length as the variant prefix.
         5) Reference sequence after the variant locus, untrimmed.
         6) Number of nucleotides trimmed from the reference sequence, used
-           later for adjustint offset to first complete codon.
+           later for adjusting offset to first complete codon.
     """
     cdna_prefix = variant_sequence.prefix
     cdna_alt = variant_sequence.alt
@@ -219,7 +219,7 @@ def trim_sequences(variant_sequence, reference_context):
         cdna_suffix,
         reference_sequence_before_variant,
         reference_sequence_after_variant,
-        n_trimmed_from_reference
+        n_trimmed_from_reference,
     )
 
 

--- a/isovar/variant_orf_helpers.py
+++ b/isovar/variant_orf_helpers.py
@@ -62,8 +62,6 @@ def match_variant_sequence_to_reference_context(
 
     Returns VariantORF or None
     """
-    variant_orf = None
-
     # if we can't get the variant sequence to match this reference
     # context then keep trimming it by coverage until either
     for i in range(max_trimming_attempts + 1):
@@ -97,10 +95,11 @@ def match_variant_sequence_to_reference_context(
         n_mismatch_after_variant = (
             variant_orf.num_mismatches_after_variant)
 
-        logger.info("Iter #%d/%d: %s" % (
+        logger.info("Iter #%d/%d: %s (len=%d)" % (
             i + 1,
             max_trimming_attempts + 1,
-            variant_orf))
+            variant_orf,
+            len(variant_orf.cdna_sequence)))
 
         total_mismatches = n_mismatch_before_variant
         if count_mismatches_after_variant:

--- a/isovar/variant_orf_helpers.py
+++ b/isovar/variant_orf_helpers.py
@@ -78,7 +78,7 @@ def match_variant_sequence_to_reference_context(
         )
         if variant_sequence_too_short:
             logger.info(
-                "Variant sequence %s shorter than min allowed %d (iter=%d)",
+                "Prefix of variant sequence %s shorter than min allowed %d (iter=%d)",
                 variant_sequence,
                 min_transcript_prefix_length,
                 i + 1)

--- a/isovar/variant_sequence.py
+++ b/isovar/variant_sequence.py
@@ -51,6 +51,22 @@ class VariantSequence(ValueObject):
     def __len__(self):
         return len(self.sequence)
 
+    def __str__(self):
+        return (
+            "VariantSequence("
+            "prefix='%s', alt='%s', "
+            "suffix='%s', sequence='%s', "
+            "reads=<%d AlleleRead object%s>)") % (
+                self.prefix,
+                self.alt,
+                self.suffix,
+                self.sequence,
+                len(self.reads),
+                "s" if len(self.reads) == 0 or len(self.reads) > 1 else "")
+
+    def __repr__(self):
+        return str(self)
+
     @property
     def read_names(self):
         """

--- a/test/test_protein_sequences.py
+++ b/test/test_protein_sequences.py
@@ -125,6 +125,29 @@ def test_variants_to_protein_sequences_dataframe_filtered_all_reads_by_mapping_q
         "Expected 0 entries, got %d: %s" % (len(df), df))
 
 
+def test_protein_sequence_creator_protein_length():
+    variants = load_vcf("data/b16.f10/b16.vcf")
+    alignment_file = load_bam("data/b16.f10/b16.combined.sorted.bam")
+    read_collector = ReadCollector()
+
+    for desired_length in [10, 12, 14, 16]:
+        creator = ProteinSequenceCreator(
+            max_protein_sequences_per_variant=1,
+            protein_sequence_length=desired_length)
+        read_evidence_gen = read_collector.read_evidence_generator(
+            variants=variants,
+            alignment_file=alignment_file)
+        protein_sequences_generator = creator.protein_sequences_from_read_evidence_generator(
+           read_evidence_gen)
+        df = protein_sequences_generator_to_dataframe(protein_sequences_generator)
+        print(df)
+        protein_sequences = df["amino_acids"]
+        print(protein_sequences)
+        protein_sequence_lengths = protein_sequences.str.len()
+        assert (protein_sequence_lengths == desired_length).all(), (
+            protein_sequence_lengths,)
+
+
 def test_variants_to_protein_sequences_dataframe_protein_sequence_length():
     expressed_variants = load_vcf("data/b16.f10/b16.expressed.vcf")
     parser = make_protein_sequences_arg_parser()

--- a/test/test_protein_sequences.py
+++ b/test/test_protein_sequences.py
@@ -130,7 +130,7 @@ def test_protein_sequence_creator_protein_length():
     alignment_file = load_bam("data/b16.f10/b16.combined.sorted.bam")
     read_collector = ReadCollector()
 
-    for desired_length in [10, 12, 14, 16]:
+    for desired_length in [21, 15, 10]:
         creator = ProteinSequenceCreator(
             max_protein_sequences_per_variant=1,
             protein_sequence_length=desired_length)


### PR DESCRIPTION
I found two problems: peptide sequence length seemed to be capped at 24mer and the number of mismatches after the variant always seemed to be non-zero (https://github.com/openvax/isovar/issues/110). 

This PR fixes these problems by getting rid of the very subtle parameter (`--reference-context-size`). 