### PR TITLE
Replace deprecated pkg_resources logging lookup

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 
 
 from .allele_read import AlleleRead

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,14 +10,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from importlib import resources
-import logging
-import logging.config
+import subprocess
+import sys
 
 
-def get_logger(name):
-    config_resource = resources.files("isovar").joinpath("logging.conf")
-    with resources.as_file(config_resource) as config_path:
-        logging.config.fileConfig(config_path)
-    return logging.getLogger(name)
+def test_import_isovar_does_not_use_pkg_resources():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error:pkg_resources is deprecated as an API:UserWarning",
+            "-c",
+            (
+                "import sys\n"
+                "import isovar\n"
+                "assert 'pkg_resources' not in sys.modules\n"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- replace `pkg_resources.resource_filename` with `importlib.resources.files` and `as_file`
- add a subprocess regression test that treats the deprecation warning as an error and verifies imports no longer load `pkg_resources`
- bump the package version from 1.7.1 to 1.7.2

## Why

Importing isovar currently loads the deprecated `pkg_resources` API solely to locate the bundled logging configuration. Newer setuptools versions warn during import, which can pollute downstream CLI output before commands such as Vaxrank help are displayed.

The standard-library resource API preserves access to the packaged `logging.conf` without depending on setuptools at runtime.

Closes #190.

## Validation

- `./lint.sh`
- `./test.sh` — 218 passed, 94% coverage
