### PR TITLE
Defer variant sequence ranking until after translation

### DIFF
--- a/isovar/variant_sequence_creator.py
+++ b/isovar/variant_sequence_creator.py
@@ -70,7 +70,7 @@ class VariantSequenceCreator(object):
         """
         Collapse variant-supporting RNA reads into consensus sequences of
         approximately the preferred length (may differ at the ends of transcripts),
-        filter consensus sequences by length and number of supporting RNA reads.
+        and trim consensus sequences to the requested RNA read coverage.
 
         Parameters
         ----------
@@ -145,13 +145,13 @@ class VariantSequenceCreator(object):
 
         if variant_sequences:
             logger.info(
-                ("After coverage & length filtering: %d variant sequences "
+                ("After coverage filtering: %d variant sequences "
                  "(min length=%d, max length=%d)"),
                 len(variant_sequences),
                 min(len(s) for s in variant_sequences),
                 max(len(s) for s in variant_sequences))
         else:
-            logger.info("After coverage & length filtering: 0 variant sequences")
+            logger.info("After coverage filtering: 0 variant sequences")
             return []
 
         # sort VariantSequence objects by decreasing order of supporting read

--- a/isovar/variant_sequence_helpers.py
+++ b/isovar/variant_sequence_helpers.py
@@ -99,84 +99,46 @@ def filter_variant_sequences_by_length(
         variant_sequences,
         preferred_sequence_length):
     """
-    Drop variant sequences shorter than the longest one we managed to
-    construct (capped at preferred_sequence_length), except for shorter
-    sequences with strictly better fragment support.
+    Retain nonempty variant sequences for downstream translation.
 
-    Length on its own is a poor way to choose between candidates once the
-    requested sequence is longer than a single read, since assembled length
-    then reflects how far a chain of overlapping reads happened to extend
-    rather than how well supported that chain is. A long sequence built from
-    two reads can evict a shorter one built from ten.
+    This function historically dropped every sequence shorter than the
+    longest observed sequence (capped at ``preferred_sequence_length``). That
+    decision cannot be made safely before translation: a longer sequence may
+    fail to match every reference context, raw read counts are only the second
+    part of the downstream support ordering, and multiple cDNA sequences may
+    be grouped into one protein sequence whose combined support beats every
+    individual candidate.
 
-    Isovar's actual preference order is spelled out by
-    ProteinSequence.ascending_sort_key: supporting fragments, then supporting
-    reads, then mismatches against the reference transcript, and only then
-    length as a tie-break. We can't apply all of it here because mismatch
-    counts don't exist until a VariantSequence has been matched against a
-    ReferenceContext. So instead of committing to length at this stage, keep
-    any better-supported shorter candidate and let the downstream ranking in
-    protein_sequence_helpers.sort_protein_sequences decide.
+    Keep the legacy function name and ``preferred_sequence_length`` argument
+    for API compatibility, but defer all candidate ranking until after
+    reference matching and translation. Remove zero-length sequences here as
+    a defense in depth; ``trim_variant_sequences`` normally removes them where
+    they are produced.
 
     Parameters
     ----------
     variant_sequences : list of VariantSequence
 
     preferred_sequence_length : int
-        If we get some sequences which are at least this long and others
-        which are shorter, then drop the shorter ones.
+        Retained for API compatibility. Initial sequence construction already
+        uses this value to bound assembled sequence length.
 
     Returns
     -------
     list of VariantSequence
     """
     n_total = len(variant_sequences)
-    if n_total == 0:
-        return []
-    # since we might have gotten some shorter fragments,
-    # keep only the longest spanning sequence
-    max_observed_sequence_length = max(len(s) for s in variant_sequences)
-
-    # if we get back a sequence that's longer than the preferred length
-    # then that doesn't mean we should necessarily drop the other sequences
-    min_required_sequence_length = min(
-        max_observed_sequence_length,
-        preferred_sequence_length)
-
-    long_enough = [
+    nonempty_variant_sequences = [
         s for s in variant_sequences
-        if len(s.sequence) >= min_required_sequence_length
+        if len(s) > 0
     ]
-    # number of distinct fragments (not reads) behind the best long sequence,
-    # matching the unit used by ProteinSequence.num_supporting_fragments
-    best_long_support = max(len(s.read_names) for s in long_enough)
-    # a zero length sequence can't be rescued no matter how many reads it
-    # claims, since trim_by_coverage hands back all of the original reads
-    # along with an empty sequence
-    better_supported = [
-        s for s in variant_sequences
-        if len(s.sequence) < min_required_sequence_length
-        and len(s.sequence) > 0
-        and len(s.read_names) > best_long_support
-    ]
-    variant_sequences = long_enough + better_supported
-
-    n_dropped = n_total - len(variant_sequences)
+    n_dropped = n_total - len(nonempty_variant_sequences)
     if n_dropped > 0:
         logger.info(
-            "Dropped %d/%d variant sequences shorter than %d",
+            "Dropped %d/%d empty variant sequences before translation",
             n_dropped,
-            n_total,
-            min_required_sequence_length)
-    for s in better_supported:
-        logger.info(
-            ("Keeping variant sequence shorter than %d (len=%d) since its %d "
-             "supporting fragments beat the %d supporting the longest sequence"),
-            min_required_sequence_length,
-            len(s.sequence),
-            len(s.read_names),
-            best_long_support)
-    return variant_sequences
+            n_total)
+    return nonempty_variant_sequences
 
 
 def trim_variant_sequences(variant_sequences, min_variant_sequence_coverage):
@@ -197,7 +159,7 @@ def trim_variant_sequences(variant_sequences, min_variant_sequence_coverage):
     # returns an empty sequence which still carries every one of the original
     # reads. Those sequences are useless downstream and their read counts are
     # actively misleading when comparing candidates by support, so drop them
-    # here rather than relying on a later length filter to sweep them up.
+    # here rather than relying on a later validity check to sweep them up.
     trimmed_variant_sequences = [
         trimmed
         for trimmed in (
@@ -221,8 +183,12 @@ def filter_variant_sequences(
         preferred_sequence_length,
         min_variant_sequence_coverage):
     """
-    Drop variant sequences which are shorter than request or don't have
-    enough supporting reads.
+    Trim variant sequences to the requested coverage and discard any which
+    contain no usable sequence afterward.
+
+    Candidate ranking is deliberately deferred until after reference matching
+    and translation, when transcript mismatches and aggregate protein support
+    are available.
 
     Parameters
     ----------
@@ -240,4 +206,3 @@ def filter_variant_sequences(
     return filter_variant_sequences_by_length(
         variant_sequences=variant_sequences,
         preferred_sequence_length=preferred_sequence_length)
-

--- a/isovar/variant_sequence_helpers.py
+++ b/isovar/variant_sequence_helpers.py
@@ -193,9 +193,18 @@ def trim_variant_sequences(variant_sequences, min_variant_sequence_coverage):
     Returns list of VariantSequence
     """
     n_total = len(variant_sequences)
+    # when no base of a sequence has sufficient coverage, trim_by_coverage
+    # returns an empty sequence which still carries every one of the original
+    # reads. Those sequences are useless downstream and their read counts are
+    # actively misleading when comparing candidates by support, so drop them
+    # here rather than relying on a later length filter to sweep them up.
     trimmed_variant_sequences = [
-        variant_sequence.trim_by_coverage(min_variant_sequence_coverage)
-        for variant_sequence in variant_sequences
+        trimmed
+        for trimmed in (
+            variant_sequence.trim_by_coverage(min_variant_sequence_coverage)
+            for variant_sequence in variant_sequences
+        )
+        if len(trimmed) > 0
     ]
     collapsed_variant_sequences = collapse_substrings(trimmed_variant_sequences)
     n_after_trimming = len(collapsed_variant_sequences)

--- a/isovar/variant_sequence_helpers.py
+++ b/isovar/variant_sequence_helpers.py
@@ -99,6 +99,25 @@ def filter_variant_sequences_by_length(
         variant_sequences,
         preferred_sequence_length):
     """
+    Drop variant sequences shorter than the longest one we managed to
+    construct (capped at preferred_sequence_length), except for shorter
+    sequences with strictly better fragment support.
+
+    Length on its own is a poor way to choose between candidates once the
+    requested sequence is longer than a single read, since assembled length
+    then reflects how far a chain of overlapping reads happened to extend
+    rather than how well supported that chain is. A long sequence built from
+    two reads can evict a shorter one built from ten.
+
+    Isovar's actual preference order is spelled out by
+    ProteinSequence.ascending_sort_key: supporting fragments, then supporting
+    reads, then mismatches against the reference transcript, and only then
+    length as a tie-break. We can't apply all of it here because mismatch
+    counts don't exist until a VariantSequence has been matched against a
+    ReferenceContext. So instead of committing to length at this stage, keep
+    any better-supported shorter candidate and let the downstream ranking in
+    protein_sequence_helpers.sort_protein_sequences decide.
+
     Parameters
     ----------
     variant_sequences : list of VariantSequence
@@ -124,10 +143,24 @@ def filter_variant_sequences_by_length(
         max_observed_sequence_length,
         preferred_sequence_length)
 
-    variant_sequences = [
+    long_enough = [
         s for s in variant_sequences
         if len(s.sequence) >= min_required_sequence_length
     ]
+    # number of distinct fragments (not reads) behind the best long sequence,
+    # matching the unit used by ProteinSequence.num_supporting_fragments
+    best_long_support = max(len(s.read_names) for s in long_enough)
+    # a zero length sequence can't be rescued no matter how many reads it
+    # claims, since trim_by_coverage hands back all of the original reads
+    # along with an empty sequence
+    better_supported = [
+        s for s in variant_sequences
+        if len(s.sequence) < min_required_sequence_length
+        and len(s.sequence) > 0
+        and len(s.read_names) > best_long_support
+    ]
+    variant_sequences = long_enough + better_supported
+
     n_dropped = n_total - len(variant_sequences)
     if n_dropped > 0:
         logger.info(
@@ -135,6 +168,14 @@ def filter_variant_sequences_by_length(
             n_dropped,
             n_total,
             min_required_sequence_length)
+    for s in better_supported:
+        logger.info(
+            ("Keeping variant sequence shorter than %d (len=%d) since its %d "
+             "supporting fragments beat the %d supporting the longest sequence"),
+            min_required_sequence_length,
+            len(s.sequence),
+            len(s.read_names),
+            best_long_support)
     return variant_sequences
 
 

--- a/tests/test_protein_sequences.py
+++ b/tests/test_protein_sequences.py
@@ -12,6 +12,7 @@
 
 from varcode import VariantCollection
 
+from isovar.allele_read import AlleleRead
 from isovar.read_collector import ReadCollector
 from isovar.cli.protein_sequence_args import (
     protein_sequences_dataframe_from_args,
@@ -20,11 +21,56 @@ from isovar.cli.protein_sequence_args import (
 from isovar.dataframe_helpers import protein_sequences_generator_to_dataframe
 from isovar.main import ProteinSequenceCreator
 from isovar.protein_sequence import ProteinSequence
-from isovar.protein_sequence_helpers import sort_protein_sequences
+from isovar.protein_sequence_helpers import (
+    group_equivalent_translations,
+    sort_protein_sequences,
+)
+from isovar.translation import Translation
+from isovar.variant_orf import VariantORF
+from isovar.variant_sequence import VariantSequence
 
 from .common import eq_
 from .testing_helpers import load_bam, load_vcf, data_path
 from .mock_objects import make_dummy_protein_sequence
+
+
+def _translation_with_reads(amino_acids, reads, cdna_sequence):
+    variant_sequence = VariantSequence(
+        prefix="AAA",
+        alt="C",
+        suffix="TTT",
+        reads=reads)
+    variant_orf = VariantORF(
+        cdna_sequence=cdna_sequence,
+        offset_to_first_complete_codon=0,
+        variant_cdna_interval_start=3,
+        variant_cdna_interval_end=4,
+        reference_cdna_sequence_before_variant="AAA",
+        reference_cdna_sequence_after_variant="TTT",
+        num_mismatches_before_variant=0,
+        num_mismatches_after_variant=0)
+    return Translation(
+        amino_acids=amino_acids,
+        contains_mutation=True,
+        mutation_start_idx=1,
+        mutation_end_idx=2,
+        ends_with_stop_codon=False,
+        frameshift=False,
+        untrimmed_variant_sequence=variant_sequence,
+        reference_context=None,
+        variant_orf=variant_orf)
+
+
+def _reads(name_prefix, n_fragments, source_read_count=1):
+    return [
+        AlleleRead(
+            prefix="AAA",
+            allele="C",
+            suffix="TTT",
+            name="%s_%d" % (name_prefix, i),
+            source_read_count=source_read_count)
+        for i in range(n_fragments)
+    ]
 
 
 def test_protein_sequence_substitution():
@@ -183,6 +229,57 @@ def test_sort_protein_sequences():
         protseq_fewest_reads,
     ]
     eq_(sort_protein_sequences(unsorted_protein_sequences), expected_order)
+
+
+def test_sort_protein_sequences_uses_raw_reads_before_length():
+    short_translation = _translation_with_reads(
+        amino_acids="MKH",
+        reads=_reads("short", n_fragments=3, source_read_count=2),
+        cdna_sequence="ATGAAACAC")
+    long_translation = _translation_with_reads(
+        amino_acids="MKHW",
+        reads=_reads("long", n_fragments=3, source_read_count=1),
+        cdna_sequence="ATGAAACACTGG")
+    short_protein = ProteinSequence.from_translations([short_translation])
+    long_protein = ProteinSequence.from_translations([long_translation])
+
+    sorted_proteins = sort_protein_sequences([long_protein, short_protein])
+
+    eq_(short_protein.num_supporting_fragments, 3)
+    eq_(long_protein.num_supporting_fragments, 3)
+    eq_(short_protein.num_supporting_reads, 6)
+    eq_(long_protein.num_supporting_reads, 3)
+    eq_(sorted_proteins, [short_protein, long_protein])
+
+
+def test_grouped_protein_support_can_beat_each_individual_cdna_sequence():
+    short_translation_1 = _translation_with_reads(
+        amino_acids="MKH",
+        reads=_reads("short_1", n_fragments=2),
+        cdna_sequence="ATGAAACAC")
+    # A synonymous final codon makes this a distinct cDNA translation of the
+    # same protein, supported by a disjoint set of fragments.
+    short_translation_2 = _translation_with_reads(
+        amino_acids="MKH",
+        reads=_reads("short_2", n_fragments=2),
+        cdna_sequence="ATGAAACAT")
+    long_translation = _translation_with_reads(
+        amino_acids="MKHW",
+        reads=_reads("long", n_fragments=3),
+        cdna_sequence="ATGAAACACTGG")
+
+    proteins = group_equivalent_translations([
+        short_translation_1,
+        short_translation_2,
+        long_translation,
+    ])
+    sorted_proteins = sort_protein_sequences(proteins)
+
+    eq_(len(proteins), 2)
+    eq_(sorted_proteins[0].amino_acids, "MKH")
+    eq_(sorted_proteins[0].num_supporting_fragments, 4)
+    eq_(sorted_proteins[1].amino_acids, "MKHW")
+    eq_(sorted_proteins[1].num_supporting_fragments, 3)
 
 
 def variants_to_protein_sequences_dataframe(

--- a/tests/test_variant_orf.py
+++ b/tests/test_variant_orf.py
@@ -22,8 +22,11 @@ from isovar.reference_coding_sequence_key import ReferenceCodingSequenceKey
 from isovar.reference_context import ReferenceContext
 from isovar.allele_read import AlleleRead
 from isovar.dna import reverse_complement_dna
+from isovar.protein_sequence_creator import ProteinSequenceCreator
+from isovar.variant_sequence_helpers import filter_variant_sequences
 
 from .common import eq_ 
+from .genomes_for_testing import grch38
 
 def test_compute_offset_to_first_complete_codon_no_trimming():
     # if nothing gets trimmed from the reference sequence, then
@@ -186,6 +189,105 @@ def make_inputs_for_tp53_201_variant(
     assert isinstance(expected, VariantORF)
 
     return variant_sequence, reference_context, expected
+
+
+def test_filter_variant_sequences_defers_reference_compatibility():
+    """
+    A longer assembly can be unusable even when it has greater read support.
+
+    Reference compatibility is unavailable during variant-sequence filtering,
+    so the shorter compatible candidate must reach the translation stage.
+    """
+    base_sequence, reference_context, _ = make_inputs_for_tp53_201_variant()
+
+    def with_support(suffix, n_fragments, name_prefix):
+        reads = [
+            AlleleRead(
+                prefix=base_sequence.prefix,
+                allele=base_sequence.alt,
+                suffix=suffix,
+                name="%s_%d" % (name_prefix, i))
+            for i in range(n_fragments)
+        ]
+        return VariantSequence(
+            prefix=base_sequence.prefix,
+            alt=base_sequence.alt,
+            suffix=suffix,
+            reads=reads)
+
+    compatible_short = with_support(
+        suffix=base_sequence.suffix,
+        n_fragments=3,
+        name_prefix="compatible")
+    # TP53-201 is on the negative strand. Prepending GGG to the genomic
+    # suffix makes the three cDNA bases before the variant CCC instead of ATG,
+    # exceeding max_transcript_mismatches=2 after length normalization.
+    incompatible_long = with_support(
+        suffix="GGG" + base_sequence.suffix,
+        n_fragments=4,
+        name_prefix="incompatible")
+
+    filtered = filter_variant_sequences(
+        variant_sequences=[compatible_short, incompatible_long],
+        preferred_sequence_length=len(incompatible_long),
+        min_variant_sequence_coverage=2)
+
+    creator = ProteinSequenceCreator(
+        protein_sequence_length=20,
+        min_transcript_prefix_length=3,
+        max_transcript_mismatches=2)
+    translations = creator.all_pairs_translations(
+        variant_sequences=filtered,
+        reference_contexts=[reference_context])
+
+    eq_(set(filtered), {compatible_short, incompatible_long})
+    eq_(len(translations), 1)
+    eq_(translations[0].untrimmed_variant_sequence, compatible_short)
+
+
+def test_protein_sequence_creator_translates_coding_deletion():
+    """
+    Pin deletion handling through assembly, reference matching, and translation.
+    """
+    variant = Variant("17", 7676589, "CTC", "", grch38)
+    transcript = grch38.transcripts_by_name("TP53-001")[0]
+    protein_sequence_length = 10
+    context_size = (protein_sequence_length + 1) * 3
+    reference_key = ReferenceCodingSequenceKey.from_variant_and_transcript(
+        variant=variant,
+        transcript=transcript,
+        context_size=context_size)
+
+    # AlleleRead sequences use the positive genomic strand, whereas TP53 is
+    # transcribed from the negative strand.
+    prefix = reverse_complement_dna(
+        reference_key.sequence_after_variant_locus)
+    suffix = reverse_complement_dna(
+        reference_key.sequence_before_variant_locus)
+    reads = [
+        AlleleRead(
+            prefix=prefix,
+            allele="",
+            suffix=suffix,
+            name="deletion_%d" % i)
+        for i in range(4)
+    ]
+
+    creator = ProteinSequenceCreator(
+        protein_sequence_length=protein_sequence_length,
+        min_variant_sequence_coverage=2)
+    translations = creator.translate_variant_reads(
+        variant=variant,
+        variant_reads=reads,
+        transcript_id_whitelist={transcript.id})
+
+    eq_(len(translations), 1)
+    translation = translations[0]
+    eq_(translation.amino_acids, "MEPQSD")
+    eq_(translation.contains_mutation, True)
+    eq_(translation.mutation_start_idx, 1)
+    eq_(translation.mutation_end_idx, 1)
+    eq_(translation.untrimmed_variant_sequence.alt, "")
 
 
 def test_match_variant_sequence_to_reference_context_exact_match():

--- a/tests/test_variant_sequences.py
+++ b/tests/test_variant_sequences.py
@@ -19,6 +19,7 @@ from isovar import (
 )
 from isovar.allele_read import AlleleRead
 from isovar.read_collector import ReadCollector
+from isovar.variant_sequence_helpers import filter_variant_sequences_by_length
 
 from .testing_helpers import load_bam
 from .genomes_for_testing import grch38
@@ -264,3 +265,82 @@ def test_variant_sequence_coverage_cache_excluded_from_equality():
     vs1.coverage()
     eq_(vs1, vs2, "Cached coverage should not affect equality")
     eq_(hash(vs1), hash(vs2), "Cached coverage should not affect hash")
+
+
+def _variant_sequence(prefix, alt, suffix, n_fragments, name_prefix):
+    """
+    Build a VariantSequence fully spanned by n_fragments distinct reads.
+    """
+    reads = [
+        AlleleRead(
+            prefix=prefix,
+            allele=alt,
+            suffix=suffix,
+            name="%s_%d" % (name_prefix, i))
+        for i in range(n_fragments)
+    ]
+    return VariantSequence(prefix=prefix, alt=alt, suffix=suffix, reads=reads)
+
+
+def test_filter_by_length_keeps_shorter_sequence_with_better_support():
+    # a long sequence assembled from few reads should not evict a shorter
+    # sequence supported by many more fragments, since length at this stage
+    # only reflects how far a chain of reads happened to extend
+    well_supported = _variant_sequence("A" * 20, "C", "T" * 20, 7, "concordant")
+    barely_supported = _variant_sequence("G" * 30, "C", "T" * 30, 2, "outlier")
+    kept = filter_variant_sequences_by_length(
+        [well_supported, barely_supported],
+        preferred_sequence_length=61)
+    eq_(set(kept), {well_supported, barely_supported})
+
+
+def test_filter_by_length_drops_shorter_sequence_without_better_support():
+    # unchanged behavior: length still decides when support doesn't favor
+    # the shorter sequence
+    short_sequence = _variant_sequence("A" * 20, "C", "T" * 20, 2, "short")
+    long_sequence = _variant_sequence("G" * 30, "C", "T" * 30, 7, "long")
+    kept = filter_variant_sequences_by_length(
+        [short_sequence, long_sequence],
+        preferred_sequence_length=61)
+    eq_(kept, [long_sequence])
+
+
+def test_filter_by_length_drops_shorter_sequence_with_equal_support():
+    # ties go to the longer sequence, matching the last tie-break of
+    # ProteinSequence.ascending_sort_key
+    short_sequence = _variant_sequence("A" * 20, "C", "T" * 20, 5, "short")
+    long_sequence = _variant_sequence("G" * 30, "C", "T" * 30, 5, "long")
+    kept = filter_variant_sequences_by_length(
+        [short_sequence, long_sequence],
+        preferred_sequence_length=61)
+    eq_(kept, [long_sequence])
+
+
+def test_filter_by_length_ignores_read_counts_of_empty_sequences():
+    # trim_by_coverage returns an empty sequence which keeps all of the
+    # original reads, so an empty sequence can claim more fragments than any
+    # real one. It must never be rescued on those grounds.
+    real_sequence = _variant_sequence("G" * 30, "C", "T" * 30, 2, "real")
+    empty_sequence = VariantSequence(
+        prefix="",
+        alt="",
+        suffix="",
+        reads=[
+            AlleleRead(prefix="A", allele="C", suffix="T", name="empty_%d" % i)
+            for i in range(14)
+        ])
+    kept = filter_variant_sequences_by_length(
+        [real_sequence, empty_sequence],
+        preferred_sequence_length=61)
+    eq_(kept, [real_sequence])
+
+
+def test_filter_by_length_keeps_deletion_sequences():
+    # deletions legitimately have an empty alt allele, so degenerate
+    # sequences must be identified by total length rather than by alt
+    deletion = _variant_sequence("A" * 20, "", "T" * 20, 7, "deletion")
+    longer_deletion = _variant_sequence("G" * 30, "", "T" * 30, 2, "long_deletion")
+    kept = filter_variant_sequences_by_length(
+        [deletion, longer_deletion],
+        preferred_sequence_length=61)
+    eq_(set(kept), {deletion, longer_deletion})

--- a/tests/test_variant_sequences.py
+++ b/tests/test_variant_sequences.py
@@ -20,6 +20,7 @@ from isovar import (
 from isovar.allele_read import AlleleRead
 from isovar.read_collector import ReadCollector
 from isovar.variant_sequence_helpers import (
+    filter_variant_sequences,
     filter_variant_sequences_by_length,
     trim_variant_sequences,
 )
@@ -360,3 +361,79 @@ def test_trim_variant_sequences_drops_sequences_without_coverage():
     eq_(trimmed, [covered])
     assert all(len(s) > 0 for s in trimmed), \
         "trim_variant_sequences should not return empty sequences"
+
+
+# Deletions legitimately carry an empty alt allele (see read_collector.py,
+# where is_deletion is defined as len(trimmed_alt) == 0). It is therefore
+# always wrong to identify a useless "degenerate" sequence by an empty alt;
+# the test has to be total sequence length. The tests below pin that down at
+# every stage which discards sequences, since a guard written against alt
+# would silently drop every deletion in a run while looking perfectly
+# reasonable in review.
+
+def test_trim_variant_sequences_keeps_deletion_sequences():
+    deletion = _variant_sequence("A" * 20, "", "T" * 20, 3, "deletion")
+    trimmed = trim_variant_sequences([deletion], min_variant_sequence_coverage=2)
+    eq_(trimmed, [deletion])
+    eq_(trimmed[0].alt, "")
+
+
+def test_trim_variant_sequences_distinguishes_deletion_from_degenerate():
+    # both have an empty alt; only the one whose bases lack coverage should go
+    covered_deletion = _variant_sequence("A" * 20, "", "T" * 20, 3, "covered")
+    uncovered_deletion = _variant_sequence("G" * 20, "", "C" * 20, 1, "uncovered")
+    trimmed = trim_variant_sequences(
+        [covered_deletion, uncovered_deletion],
+        min_variant_sequence_coverage=2)
+    eq_(trimmed, [covered_deletion])
+
+
+def test_filter_by_length_distinguishes_deletion_from_degenerate_sequence():
+    # a deletion and a degenerate sequence both have an empty alt, so only
+    # total length can tell them apart. The deletion is shorter and better
+    # supported, so it should be rescued; the empty one never should be,
+    # despite claiming the most fragments of all.
+    long_sequence = _variant_sequence("G" * 30, "", "T" * 30, 2, "long")
+    short_deletion = _variant_sequence("A" * 20, "", "T" * 20, 7, "deletion")
+    degenerate = VariantSequence(
+        prefix="",
+        alt="",
+        suffix="",
+        reads=[
+            AlleleRead(prefix="A", allele="", suffix="T", name="degenerate_%d" % i)
+            for i in range(14)
+        ])
+    kept = filter_variant_sequences_by_length(
+        [long_sequence, short_deletion, degenerate],
+        preferred_sequence_length=61)
+    eq_(set(kept), {long_sequence, short_deletion})
+
+
+def test_filter_variant_sequences_keeps_well_supported_deletion():
+    # trimming and length filtering together, on a deletion whose best
+    # supported sequence is not its longest
+    long_sequence = _variant_sequence("G" * 30, "", "T" * 30, 2, "long")
+    short_deletion = _variant_sequence("A" * 20, "", "T" * 20, 7, "deletion")
+    kept = filter_variant_sequences(
+        [long_sequence, short_deletion],
+        preferred_sequence_length=61,
+        min_variant_sequence_coverage=2)
+    eq_(set(kept), {long_sequence, short_deletion})
+    assert all(s.alt == "" for s in kept)
+
+
+def test_reads_to_variant_sequences_keeps_deletion():
+    # end to end through the creator: a deletion supported by well covered
+    # reads must survive assembly, trimming and length filtering
+    variant = Variant("chr12", 65857041, "G", "", grch38)
+    prefix, suffix = "A" * 30, "T" * 30
+    reads = [
+        AlleleRead(prefix=prefix, allele="", suffix=suffix, name="deletion_%d" % i)
+        for i in range(4)
+    ]
+    creator = VariantSequenceCreator(preferred_sequence_length=61)
+    variant_sequences = creator.reads_to_variant_sequences(
+        variant=variant, reads=reads)
+    eq_(len(variant_sequences), 1)
+    eq_(variant_sequences[0].alt, "")
+    eq_(variant_sequences[0].sequence, prefix + suffix)

--- a/tests/test_variant_sequences.py
+++ b/tests/test_variant_sequences.py
@@ -11,6 +11,8 @@
 # limitations under the License.
 
 
+from itertools import permutations
+
 from varcode import Variant
 
 from isovar import (
@@ -298,26 +300,70 @@ def test_filter_by_length_keeps_shorter_sequence_with_better_support():
     eq_(set(kept), {well_supported, barely_supported})
 
 
-def test_filter_by_length_drops_shorter_sequence_without_better_support():
-    # unchanged behavior: length still decides when support doesn't favor
-    # the shorter sequence
+def test_filter_by_length_defers_when_longer_sequence_has_better_support():
+    # The longer sequence may fail reference matching, which cannot be known
+    # at this stage, so even a less-supported shorter candidate must survive.
     short_sequence = _variant_sequence("A" * 20, "C", "T" * 20, 2, "short")
     long_sequence = _variant_sequence("G" * 30, "C", "T" * 30, 7, "long")
     kept = filter_variant_sequences_by_length(
         [short_sequence, long_sequence],
         preferred_sequence_length=61)
-    eq_(kept, [long_sequence])
+    eq_(kept, [short_sequence, long_sequence])
 
 
-def test_filter_by_length_drops_shorter_sequence_with_equal_support():
-    # ties go to the longer sequence, matching the last tie-break of
-    # ProteinSequence.ascending_sort_key
+def test_filter_by_length_defers_when_sequences_have_equal_fragment_support():
+    # Fragment equality is not enough to choose: raw read counts, reference
+    # mismatches, and aggregate support are only available downstream.
     short_sequence = _variant_sequence("A" * 20, "C", "T" * 20, 5, "short")
     long_sequence = _variant_sequence("G" * 30, "C", "T" * 30, 5, "long")
     kept = filter_variant_sequences_by_length(
         [short_sequence, long_sequence],
         preferred_sequence_length=61)
-    eq_(kept, [long_sequence])
+    eq_(kept, [short_sequence, long_sequence])
+
+
+def test_filter_by_length_defers_raw_read_count_tie_break():
+    # Merged mates have one fragment name but preserve both raw reads through
+    # source_read_count. The final ProteinSequence sort ranks this count before
+    # length, so a fragment-only early filter would choose incorrectly.
+    short_reads = [
+        AlleleRead(
+            prefix="A" * 20,
+            allele="C",
+            suffix="T" * 20,
+            name="short_%d" % i,
+            source_read_count=2)
+        for i in range(3)
+    ]
+    short_sequence = VariantSequence(
+        prefix="A" * 20,
+        alt="C",
+        suffix="T" * 20,
+        reads=short_reads)
+    long_sequence = _variant_sequence("G" * 30, "C", "T" * 30, 3, "long")
+
+    kept = filter_variant_sequences_by_length(
+        [short_sequence, long_sequence],
+        preferred_sequence_length=61)
+
+    eq_(kept, [short_sequence, long_sequence])
+    eq_(sum(r.source_read_count for r in short_sequence.reads), 6)
+    eq_(sum(r.source_read_count for r in long_sequence.reads), 3)
+
+
+def test_filter_by_length_defers_aggregate_protein_support():
+    # Distinct cDNA candidates can translate to the same amino-acid sequence.
+    # Their disjoint reads are unioned only after translation, so neither can
+    # be discarded based on its individual support here.
+    short_1 = _variant_sequence("A" * 20, "C", "T" * 20, 2, "short_1")
+    short_2 = _variant_sequence("G" * 20, "C", "T" * 20, 2, "short_2")
+    long_sequence = _variant_sequence("C" * 30, "C", "T" * 30, 3, "long")
+
+    kept = filter_variant_sequences_by_length(
+        [short_1, short_2, long_sequence],
+        preferred_sequence_length=61)
+
+    eq_(kept, [short_1, short_2, long_sequence])
 
 
 def test_filter_by_length_ignores_read_counts_of_empty_sequences():
@@ -337,6 +383,40 @@ def test_filter_by_length_ignores_read_counts_of_empty_sequences():
         [real_sequence, empty_sequence],
         preferred_sequence_length=61)
     eq_(kept, [real_sequence])
+
+
+def test_filter_by_length_drops_empty_sequence_when_it_is_the_only_candidate():
+    degenerate = VariantSequence(
+        prefix="",
+        alt="",
+        suffix="",
+        reads=[AlleleRead(prefix="A", allele="", suffix="T", name="empty")])
+
+    kept = filter_variant_sequences_by_length(
+        [degenerate],
+        preferred_sequence_length=61)
+
+    eq_(kept, [])
+
+
+def test_filter_by_length_retains_nonempty_candidates_for_every_input_order():
+    short = _variant_sequence("A" * 10, "C", "T" * 10, 2, "short")
+    long = _variant_sequence("G" * 30, "C", "T" * 30, 5, "long")
+    deletion = _variant_sequence("C" * 20, "", "A" * 20, 3, "deletion")
+    degenerate = VariantSequence(
+        prefix="",
+        alt="",
+        suffix="",
+        reads=[AlleleRead(prefix="A", allele="", suffix="T", name="empty")])
+
+    for preferred_sequence_length in (0, 21, 41, 61, 1000):
+        for ordered_candidates in permutations(
+                [short, long, deletion, degenerate]):
+            kept = filter_variant_sequences_by_length(
+                list(ordered_candidates),
+                preferred_sequence_length=preferred_sequence_length)
+            expected = [s for s in ordered_candidates if len(s) > 0]
+            eq_(kept, expected)
 
 
 def test_filter_by_length_keeps_deletion_sequences():
@@ -410,8 +490,8 @@ def test_filter_by_length_distinguishes_deletion_from_degenerate_sequence():
 
 
 def test_filter_variant_sequences_keeps_well_supported_deletion():
-    # trimming and length filtering together, on a deletion whose best
-    # supported sequence is not its longest
+    # Coverage trimming and defensive validity filtering together, on a
+    # deletion whose best supported sequence is not its longest.
     long_sequence = _variant_sequence("G" * 30, "", "T" * 30, 2, "long")
     short_deletion = _variant_sequence("A" * 20, "", "T" * 20, 7, "deletion")
     kept = filter_variant_sequences(
@@ -424,7 +504,7 @@ def test_filter_variant_sequences_keeps_well_supported_deletion():
 
 def test_reads_to_variant_sequences_keeps_deletion():
     # end to end through the creator: a deletion supported by well covered
-    # reads must survive assembly, trimming and length filtering
+    # reads must survive assembly, coverage trimming, and validity filtering
     variant = Variant("chr12", 65857041, "G", "", grch38)
     prefix, suffix = "A" * 30, "T" * 30
     reads = [

--- a/tests/test_variant_sequences.py
+++ b/tests/test_variant_sequences.py
@@ -19,7 +19,10 @@ from isovar import (
 )
 from isovar.allele_read import AlleleRead
 from isovar.read_collector import ReadCollector
-from isovar.variant_sequence_helpers import filter_variant_sequences_by_length
+from isovar.variant_sequence_helpers import (
+    filter_variant_sequences_by_length,
+    trim_variant_sequences,
+)
 
 from .testing_helpers import load_bam
 from .genomes_for_testing import grch38
@@ -344,3 +347,16 @@ def test_filter_by_length_keeps_deletion_sequences():
         [deletion, longer_deletion],
         preferred_sequence_length=61)
     eq_(set(kept), {deletion, longer_deletion})
+
+
+def test_trim_variant_sequences_drops_sequences_without_coverage():
+    # one fragment can't meet a 2x coverage threshold, so trimming leaves an
+    # empty sequence which should be discarded rather than passed along
+    uncovered = _variant_sequence("A" * 20, "C", "T" * 20, 1, "uncovered")
+    covered = _variant_sequence("G" * 20, "C", "T" * 20, 3, "covered")
+    trimmed = trim_variant_sequences(
+        [uncovered, covered],
+        min_variant_sequence_coverage=2)
+    eq_(trimmed, [covered])
+    assert all(len(s) > 0 for s in trimmed), \
+        "trim_variant_sequences should not return empty sequences"


### PR DESCRIPTION
Fixes #192.

## Problem

`filter_variant_sequences_by_length` discarded candidates before reference compatibility, raw-read support, and aggregate protein support were available. The first patch rescued a shorter sequence only when its fragment count exceeded every long candidate, but review found that this still lost valid output when:

- a longer, equally or better-supported assembly failed reference matching;
- fragment counts tied but the shorter candidate represented more raw reads through `source_read_count`; or
- multiple shorter cDNA translations grouped into one protein whose union of fragments beat an individual longer candidate.

A concrete TP53 reproduction had a compatible 21-nt candidate with 3 fragments and an incompatible 24-nt candidate with 4 fragments. Hard length/support pruning retained only the latter and changed one valid translation into zero.

## Change

- Retain every nonempty variant-sequence candidate through reference matching and translation.
- Preserve `filter_variant_sequences_by_length` and its argument for API compatibility, but make it a defensive zero-length filter. Initial sequence construction already uses the preferred length as its upper bound.
- Continue dropping zero-length coverage-trim results at their source, using total sequence length rather than `alt`, because deletions legitimately have an empty alternate allele.
- Update logging and documentation so production output no longer claims that candidates were length-filtered.
- Let the existing post-translation protein grouping, ranking, and result cap make the informed choice.

## Regression coverage

The branch now tests:

- shorter candidates with better, equal, and worse fragment support;
- raw-read count as the second downstream tie-break;
- support aggregated across equivalent cDNA translations;
- a longer, better-supported but reference-incompatible TP53 assembly alongside a valid shorter one;
- empty-only input and mixed empty/nonempty input;
- every ordering of SNV, deletion, short, long, and degenerate candidates across five preferred lengths;
- deletion safety at coverage trimming, defensive filtering, their composition, and `VariantSequenceCreator`;
- a real TP53 p.E2del through assembly, reference matching, and protein translation.

The TP53 protein expectation was checked against UniProt P04637: the reference begins `MEEPQSD`, so deleting codon 2 yields `MEPQSD`.

## Mutation checks

- Changing the trim guard to `len(trimmed.alt) > 0`: 5 targeted failures.
- Changing the defensive filter to `len(s.alt) > 0`: 5 targeted failures.
- Restoring hard length pruning: 7 targeted failures, including the reference-compatibility regression.

## Verification

- `./lint.sh`: pass.
- `./test.sh`: 237 passed, 94% coverage.
- Bundled B16 BAM/VCF at Vaxrank-like 35-aa / 108-nt settings: 2 candidates with the lossless handoff versus 2 under the old length cut; 2 final protein sequences; 0.25 seconds locally.

Reference-transcript elongation remains tracked separately in #66.