### PR TITLE
Make releases versioned, verified, and resumable

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,165 @@
-./lint.sh && \
-./test.sh && \
-python3 -m pip install --upgrade build && \
-python3 -m pip install --upgrade twine && \
-rm -rf dist && \
-python3 -m build && \
-python3 -m twine upload dist/*
+#!/usr/bin/env bash
+set -euo pipefail
 
+usage() {
+  echo "Usage: ./deploy.sh [--dry-run] [version]" >&2
+}
+
+DRY_RUN=0
+VERSION_INPUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -z "${VERSION_INPUT}" ]]; then
+        VERSION_INPUT="$1"
+        shift
+      else
+        echo "Unexpected argument: $1" >&2
+        usage
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "${CURRENT_BRANCH}" != "main" && "${CURRENT_BRANCH}" != "master" ]]; then
+  echo "Deploys are only allowed from main or master (current: ${CURRENT_BRANCH})." >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Working tree not clean; commit or stash changes before deploy." >&2
+  exit 1
+fi
+
+PYTHON="${PYTHON:-python3}"
+if [[ -x ".venv/bin/python" ]]; then
+  PYTHON=".venv/bin/python"
+fi
+
+CURRENT_VERSION="$(
+  "$PYTHON" - <<'PY'
+import re
+from pathlib import Path
+
+text = Path("isovar/__init__.py").read_text()
+match = re.search(r'__version__ = "([^"]+)"', text)
+if not match:
+    raise SystemExit("Failed to read isovar/__init__.py; unexpected format.")
+print(match.group(1))
+PY
+)"
+
+VERSION="${CURRENT_VERSION}"
+if [[ -n "${VERSION_INPUT}" ]]; then
+  VERSION="${VERSION_INPUT#v}"
+fi
+if [[ ! "${CURRENT_VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Invalid current version in isovar/__init__.py: ${CURRENT_VERSION}" >&2
+  exit 1
+fi
+if [[ ! "${VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Invalid release version: ${VERSION}" >&2
+  exit 1
+fi
+if [[ -n "${VERSION_INPUT}" && "${VERSION}" != "${CURRENT_VERSION}" ]]; then
+  "$PYTHON" - "${CURRENT_VERSION}" "${VERSION}" <<'PY'
+import sys
+
+current = tuple(int(part) for part in sys.argv[1].split("."))
+target = tuple(int(part) for part in sys.argv[2].split("."))
+if target <= current:
+    raise SystemExit(
+        "Release version must increase: %s -> %s" % (sys.argv[1], sys.argv[2])
+    )
+PY
+fi
+
+TAG="v${VERSION}"
+LOCAL_TAG_EXISTS=0
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  LOCAL_TAG_EXISTS=1
+  TAG_COMMIT="$(git rev-parse "${TAG}^{commit}")"
+  HEAD_COMMIT="$(git rev-parse HEAD)"
+  if [[ "${VERSION}" != "${CURRENT_VERSION}" || \
+        "${TAG_COMMIT}" != "${HEAD_COMMIT}" ]]; then
+    echo "Tag ${TAG} already exists locally at a different release commit; aborting." >&2
+    exit 1
+  fi
+  echo "Resuming release from existing local tag ${TAG}."
+fi
+
+./lint.sh
+./test.sh
+
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  if [[ -n "${VERSION_INPUT}" && "${VERSION}" != "${CURRENT_VERSION}" ]]; then
+    echo "Dry run: would bump ${CURRENT_VERSION} to ${VERSION}."
+  fi
+  echo "Dry run: local gates passed for ${TAG}; no files or remote state changed."
+  exit 0
+fi
+
+set +e
+git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1
+REMOTE_TAG_STATUS=$?
+set -e
+if [[ "${REMOTE_TAG_STATUS}" -eq 0 ]]; then
+  echo "Tag ${TAG} already exists on origin; aborting." >&2
+  exit 1
+elif [[ "${REMOTE_TAG_STATUS}" -ne 2 ]]; then
+  echo "Could not determine whether ${TAG} exists on origin; aborting." >&2
+  exit 1
+fi
+
+if [[ -n "${VERSION_INPUT}" && "${VERSION}" != "${CURRENT_VERSION}" ]]; then
+  VERSION="${VERSION}" "$PYTHON" - <<'PY'
+import os
+import re
+from pathlib import Path
+
+version = os.environ["VERSION"]
+path = Path("isovar/__init__.py")
+text = path.read_text()
+new_text, n = re.subn(
+    r'__version__ = "([^"]+)"',
+    '__version__ = "%s"' % version,
+    text,
+    count=1,
+)
+if n != 1:
+    raise SystemExit("Failed to update isovar/__init__.py; unexpected format.")
+path.write_text(new_text)
+PY
+  git add isovar/__init__.py
+  git commit -m "Bump version to ${VERSION}"
+fi
+
+# Always push before publishing. This also recovers cleanly if an earlier
+# attempt committed the bump locally but failed during its push.
+git push origin "${CURRENT_BRANCH}"
+
+"$PYTHON" -m pip install --upgrade build twine
+rm -rf dist build
+"$PYTHON" -m build
+"$PYTHON" -m twine check dist/*
+"$PYTHON" release_upload.py \
+  --project isovar \
+  --version "${VERSION}" \
+  dist/*
+
+if [[ "${LOCAL_TAG_EXISTS}" -eq 0 ]]; then
+  git tag "${TAG}"
+fi
+git push origin "${TAG}"
+echo "Deployed isovar ${VERSION}: https://pypi.org/project/isovar/${VERSION}/"

--- a/release_upload.py
+++ b/release_upload.py
@@ -1,0 +1,233 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bounded, idempotent PyPI uploads for isovar releases."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+from secrets import token_hex
+import subprocess
+import sys
+import time
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import urlopen
+
+
+PYPI_JSON_BASE_URL = "https://pypi.org/pypi"
+DEFAULT_UPLOAD_TIMEOUT_SECONDS = 60.0
+DEFAULT_VERIFY_TIMEOUT_SECONDS = 30.0
+DEFAULT_VERIFY_POLL_SECONDS = 1.0
+
+
+class ReleaseUploadError(RuntimeError):
+    """Raised when the complete release artifact set cannot be verified."""
+
+
+def expected_release_filenames(project, version):
+    """Return the expected pure-Python wheel and source-distribution names."""
+    wheel_project = project.replace("-", "_")
+    return frozenset({
+        "%s-%s-py3-none-any.whl" % (wheel_project, version),
+        "%s-%s.tar.gz" % (project, version),
+    })
+
+
+def pypi_release_filenames(
+        project,
+        version,
+        json_base_url=PYPI_JSON_BASE_URL,
+        request_timeout_seconds=10.0):
+    """Return the filenames published for one release in PyPI metadata."""
+    url = "%s/%s/json?cache_bust=%s" % (
+        json_base_url.rstrip("/"),
+        quote(project, safe=""),
+        token_hex(8),
+    )
+    try:
+        with urlopen(url, timeout=request_timeout_seconds) as response:
+            payload = json.load(response)
+    except HTTPError as error:
+        if error.code == 404:
+            return frozenset()
+        raise
+    releases = payload.get("releases", {})
+    return frozenset(item["filename"] for item in releases.get(version, ()))
+
+
+def upload_distribution(
+        distribution_path,
+        python_executable=sys.executable,
+        timeout_seconds=DEFAULT_UPLOAD_TIMEOUT_SECONDS,
+        repository_url=None):
+    """Upload one distribution with a finite timeout and quiet progress."""
+    command = [
+        python_executable,
+        "-m",
+        "twine",
+        "upload",
+        "--disable-progress-bar",
+    ]
+    if repository_url:
+        command.extend(["--repository-url", repository_url])
+    command.append(str(distribution_path))
+    subprocess.run(command, check=True, timeout=timeout_seconds)
+
+
+def wait_for_release_file(
+        filename,
+        fetch_release_filenames,
+        timeout_seconds=DEFAULT_VERIFY_TIMEOUT_SECONDS,
+        poll_seconds=DEFAULT_VERIFY_POLL_SECONDS):
+    """Poll release metadata until ``filename`` is visible or time expires."""
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            if filename in set(fetch_release_filenames()):
+                return True
+        except (json.JSONDecodeError, OSError, URLError):
+            # PyPI metadata can transiently fail while its release view is
+            # converging. Keep the retry bounded by the same deadline.
+            pass
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(poll_seconds, remaining))
+
+
+def publish_release(
+        distribution_paths,
+        expected_filenames,
+        fetch_release_filenames,
+        upload_file,
+        verify_timeout_seconds=DEFAULT_VERIFY_TIMEOUT_SECONDS,
+        verify_poll_seconds=DEFAULT_VERIFY_POLL_SECONDS):
+    """Upload missing artifacts and reconcile every response with PyPI state.
+
+    A timeout or nonzero Twine exit is ambiguous: the server may have accepted
+    the immutable file before the client lost its response. Verify server state
+    after every attempt and consider a file published only when its exact name
+    appears in PyPI metadata.
+    """
+    distribution_paths = tuple(distribution_paths)
+    paths_by_name = {
+        Path(distribution_path).name: Path(distribution_path)
+        for distribution_path in distribution_paths
+    }
+    expected = frozenset(expected_filenames)
+    if (len(paths_by_name) != len(distribution_paths) or
+            frozenset(paths_by_name) != expected):
+        raise ReleaseUploadError(
+            "Distribution files do not match the expected release set: "
+            "expected=%s, observed=%s" % (
+                sorted(expected),
+                sorted(paths_by_name),
+            )
+        )
+
+    published = frozenset(fetch_release_filenames())
+    for filename in sorted(expected):
+        if filename in published:
+            print("Already published: %s" % filename)
+            continue
+
+        upload_error = None
+        try:
+            upload_file(paths_by_name[filename])
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+            upload_error = error
+
+        if not wait_for_release_file(
+                filename,
+                fetch_release_filenames,
+                timeout_seconds=verify_timeout_seconds,
+                poll_seconds=verify_poll_seconds):
+            message = "PyPI did not publish %s after the upload attempt" % filename
+            if upload_error is not None:
+                raise ReleaseUploadError(message) from upload_error
+            raise ReleaseUploadError(message)
+        if upload_error is not None:
+            print("Reconciled ambiguous upload from PyPI state: %s" % filename)
+        else:
+            print("Published: %s" % filename)
+        published = frozenset(fetch_release_filenames())
+
+    published = frozenset(fetch_release_filenames())
+    missing = expected - published
+    if missing:
+        raise ReleaseUploadError(
+            "PyPI release is missing expected files: %s" % sorted(missing)
+        )
+    return published
+
+
+def main(argv=None):
+    """Upload and verify a complete isovar release."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--json-base-url", default=PYPI_JSON_BASE_URL)
+    parser.add_argument("--repository-url")
+    parser.add_argument(
+        "--upload-timeout-seconds",
+        type=float,
+        default=float(os.environ.get(
+            "ISOVAR_UPLOAD_TIMEOUT_SECONDS",
+            DEFAULT_UPLOAD_TIMEOUT_SECONDS,
+        )),
+    )
+    parser.add_argument(
+        "--verify-timeout-seconds",
+        type=float,
+        default=float(os.environ.get(
+            "ISOVAR_VERIFY_TIMEOUT_SECONDS",
+            DEFAULT_VERIFY_TIMEOUT_SECONDS,
+        )),
+    )
+    parser.add_argument("distributions", nargs="+")
+    args = parser.parse_args(argv)
+
+    expected = expected_release_filenames(args.project, args.version)
+
+    def fetch_release_filenames():
+        return pypi_release_filenames(
+            args.project,
+            args.version,
+            json_base_url=args.json_base_url,
+        )
+
+    def upload_file(path):
+        upload_distribution(
+            path,
+            python_executable=sys.executable,
+            timeout_seconds=args.upload_timeout_seconds,
+            repository_url=args.repository_url,
+        )
+
+    published = publish_release(
+        args.distributions,
+        expected_filenames=expected,
+        fetch_release_filenames=fetch_release_filenames,
+        upload_file=upload_file,
+        verify_timeout_seconds=args.verify_timeout_seconds,
+    )
+    print(
+        "Verified PyPI release files: %s" %
+        ", ".join(sorted(expected & published))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -1,0 +1,326 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+def _run(command, cwd, env=None):
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git"] + list(args),
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _release_repo(tmp_path):
+    source_root = Path(__file__).resolve().parents[1]
+    repo = tmp_path / "release-repo"
+    package_dir = repo / "isovar"
+    package_dir.mkdir(parents=True)
+    shutil.copy(source_root / "deploy.sh", repo / "deploy.sh")
+    (package_dir / "__init__.py").write_text('__version__ = "1.7.2"\n')
+    (repo / ".gitignore").write_text("__pycache__/\nbuild/\ndist/\n")
+    for script_name, output in (("lint.sh", "lint-gate"), ("test.sh", "test-gate")):
+        script = repo / script_name
+        script.write_text("#!/bin/sh\necho %s\n" % output)
+        script.chmod(0o755)
+
+    _git(repo, "init")
+    _git(repo, "checkout", "-b", "main")
+    _git(repo, "config", "user.name", "Test Release")
+    _git(repo, "config", "user.email", "release@example.com")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Initial release fixture")
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(origin)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    _git(repo, "remote", "add", "origin", str(origin))
+    _git(repo, "push", "--set-upstream", "origin", "main")
+    return repo
+
+
+def _deploy(repo, *args, env_updates=None):
+    env = os.environ.copy()
+    for name in tuple(env):
+        if name.startswith("COV_CORE_"):
+            del env[name]
+    env["PYTHON"] = sys.executable
+    if env_updates:
+        env.update(env_updates)
+    return _run(["bash", "deploy.sh"] + list(args), cwd=repo, env=env)
+
+
+def _fake_release_python(tmp_path):
+    fake_python = tmp_path / "fake-python"
+    fake_python.write_text("""#!/bin/bash
+set -eu
+if [[ "${1:-}" == "-" ]]; then
+  exec "${REAL_PYTHON}" "$@"
+elif [[ "${1:-}" == "-m" && "${2:-}" == "pip" ]]; then
+  exit 0
+elif [[ "${1:-}" == "-m" && "${2:-}" == "build" ]]; then
+  version="$("${REAL_PYTHON}" -c \
+    'import re; from pathlib import Path; print(re.search(r"__version__ = \\\"([^\\\"]+)\\\"", Path("isovar/__init__.py").read_text()).group(1))')"
+  mkdir -p dist
+  touch "dist/isovar-${version}-py3-none-any.whl"
+  touch "dist/isovar-${version}.tar.gz"
+  echo "built ${version}"
+  exit 0
+elif [[ "${1:-}" == "-m" && "${2:-}" == "twine" ]]; then
+  echo "twine-check"
+  exit 0
+elif [[ "${1:-}" == "release_upload.py" ]]; then
+  echo "release-upload $*"
+  exit 0
+fi
+exec "${REAL_PYTHON}" "$@"
+""")
+    fake_python.chmod(0o755)
+    return fake_python
+
+
+def test_deploy_dry_run_validates_without_mutating(tmp_path):
+    repo = _release_repo(tmp_path)
+
+    result = _deploy(repo, "--dry-run", "v1.7.3")
+
+    assert result.returncode == 0, result.stderr
+    assert "lint-gate" in result.stdout
+    assert "test-gate" in result.stdout
+    assert "would bump 1.7.2 to 1.7.3" in result.stdout
+    assert "no files or remote state changed" in result.stdout
+    assert (repo / "isovar" / "__init__.py").read_text() == \
+        '__version__ = "1.7.2"\n'
+    assert _git(repo, "rev-list", "--count", "HEAD").stdout.strip() == "1"
+    assert _git(repo, "status", "--porcelain").stdout == ""
+
+
+def test_deploy_rejects_non_release_branch_before_gates(tmp_path):
+    repo = _release_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")
+
+    result = _deploy(repo, "--dry-run", "1.7.3")
+
+    assert result.returncode == 1
+    assert "only allowed from main or master" in result.stderr
+    assert "lint-gate" not in result.stdout
+
+
+def test_deploy_rejects_dirty_tree_before_gates(tmp_path):
+    repo = _release_repo(tmp_path)
+    (repo / "isovar" / "__init__.py").write_text('__version__ = "dirty"\n')
+
+    result = _deploy(repo, "--dry-run", "1.7.3")
+
+    assert result.returncode == 1
+    assert "Working tree not clean" in result.stderr
+    assert "lint-gate" not in result.stdout
+
+
+def test_deploy_rejects_existing_local_tag_before_gates(tmp_path):
+    repo = _release_repo(tmp_path)
+    _git(repo, "tag", "v1.7.3")
+
+    result = _deploy(repo, "--dry-run", "1.7.3")
+
+    assert result.returncode == 1
+    assert "Tag v1.7.3 already exists locally at a different release commit" in \
+        result.stderr
+    assert "lint-gate" not in result.stdout
+
+
+@pytest.mark.parametrize("version", [
+    "definitely-not-a-version",
+    "01.7.3",
+    "1.07.3",
+    "1.7.03",
+    "1.7.3rc1",
+])
+def test_deploy_rejects_invalid_version_before_gates(tmp_path, version):
+    repo = _release_repo(tmp_path)
+
+    result = _deploy(repo, "--dry-run", version)
+
+    assert result.returncode == 1
+    assert "Invalid release version" in result.stderr
+    assert "lint-gate" not in result.stdout
+
+
+def test_deploy_rejects_version_downgrade_before_gates(tmp_path):
+    repo = _release_repo(tmp_path)
+
+    result = _deploy(repo, "1.7.1")
+
+    assert result.returncode == 1
+    assert "Release version must increase: 1.7.2 -> 1.7.1" in result.stderr
+    assert "lint-gate" not in result.stdout
+
+
+@pytest.mark.parametrize("script_name", ["lint.sh", "test.sh"])
+def test_deploy_stops_before_mutation_when_local_gate_fails(
+        tmp_path,
+        script_name):
+    repo = _release_repo(tmp_path)
+    gate_script = repo / script_name
+    gate_script.write_text("#!/bin/sh\nexit 7\n")
+    _git(repo, "add", script_name)
+    _git(repo, "commit", "-m", "Make fixture gate fail")
+    _git(repo, "push", "origin", "main")
+
+    result = _deploy(repo, "1.7.3")
+
+    assert result.returncode == 7
+    assert (repo / "isovar" / "__init__.py").read_text() == \
+        '__version__ = "1.7.2"\n'
+    assert _git(repo, "rev-list", "--count", "HEAD").stdout.strip() == "2"
+    assert _git(repo, "tag", "--list", "v1.7.3").stdout == ""
+
+
+def test_deploy_rejects_existing_remote_tag_before_mutation(tmp_path):
+    repo = _release_repo(tmp_path)
+    _git(repo, "tag", "v1.7.3")
+    _git(repo, "push", "origin", "v1.7.3")
+    _git(repo, "tag", "--delete", "v1.7.3")
+
+    result = _deploy(repo, "1.7.3")
+
+    assert result.returncode == 1
+    assert "Tag v1.7.3 already exists on origin" in result.stderr
+    assert (repo / "isovar" / "__init__.py").read_text() == \
+        '__version__ = "1.7.2"\n'
+    assert _git(repo, "rev-list", "--count", "HEAD").stdout.strip() == "1"
+
+
+def test_deploy_fails_closed_when_remote_tags_cannot_be_checked(tmp_path):
+    repo = _release_repo(tmp_path)
+    _git(repo, "remote", "set-url", "origin", str(tmp_path / "missing.git"))
+
+    result = _deploy(repo, "1.7.3")
+
+    assert result.returncode == 1
+    assert "Could not determine whether v1.7.3 exists on origin" in result.stderr
+    assert (repo / "isovar" / "__init__.py").read_text() == \
+        '__version__ = "1.7.2"\n'
+    assert _git(repo, "rev-list", "--count", "HEAD").stdout.strip() == "1"
+
+
+def test_deploy_resumes_when_valid_local_tag_has_not_reached_origin(tmp_path):
+    repo = _release_repo(tmp_path)
+    version_path = repo / "isovar" / "__init__.py"
+    version_path.write_text('__version__ = "1.7.3"\n')
+    _git(repo, "add", "isovar/__init__.py")
+    _git(repo, "commit", "-m", "Bump version to 1.7.3")
+    _git(repo, "push", "origin", "main")
+    _git(repo, "tag", "v1.7.3")
+
+    fake_python = _fake_release_python(tmp_path)
+
+    result = _deploy(
+        repo,
+        "1.7.3",
+        env_updates={
+            "PYTHON": str(fake_python),
+            "REAL_PYTHON": sys.executable,
+        })
+
+    assert result.returncode == 0, result.stderr
+    assert "Resuming release from existing local tag v1.7.3" in result.stdout
+    assert "refs/tags/v1.7.3" in _git(
+        repo, "ls-remote", "--tags", "origin", "refs/tags/v1.7.3").stdout
+    assert _git(repo, "rev-list", "--count", "HEAD").stdout.strip() == "2"
+
+
+def test_deploy_resumes_after_version_commit_push_fails(tmp_path):
+    repo = _release_repo(tmp_path)
+    origin = Path(_git(repo, "remote", "get-url", "origin").stdout.strip())
+    rejecting_hook = origin / "hooks" / "pre-receive"
+    rejecting_hook.write_text("#!/bin/sh\nexit 1\n")
+    rejecting_hook.chmod(0o755)
+
+    first_attempt = _deploy(repo, "1.7.3")
+
+    assert first_attempt.returncode != 0
+    assert (repo / "isovar" / "__init__.py").read_text() == \
+        '__version__ = "1.7.3"\n'
+    assert '__version__ = "1.7.2"' in _git(
+        repo, "show", "origin/main:isovar/__init__.py").stdout
+    assert _git(repo, "tag", "--list", "v1.7.3").stdout == ""
+
+    rejecting_hook.unlink()
+    fake_python = _fake_release_python(tmp_path)
+    second_attempt = _deploy(
+        repo,
+        "1.7.3",
+        env_updates={
+            "PYTHON": str(fake_python),
+            "REAL_PYTHON": sys.executable,
+        })
+
+    assert second_attempt.returncode == 0, second_attempt.stderr
+    assert _git(repo, "rev-list", "--count", "HEAD").stdout.strip() == "2"
+    assert '__version__ = "1.7.3"' in _git(
+        repo, "show", "origin/main:isovar/__init__.py").stdout
+    assert "refs/tags/v1.7.3" in _git(
+        repo, "ls-remote", "--tags", "origin", "refs/tags/v1.7.3").stdout
+
+
+def test_deploy_bumps_pushes_builds_uploads_and_tags(tmp_path):
+    repo = _release_repo(tmp_path)
+    fake_python = _fake_release_python(tmp_path)
+
+    result = _deploy(
+        repo,
+        "1.7.3",
+        env_updates={
+            "PYTHON": str(fake_python),
+            "REAL_PYTHON": sys.executable,
+        })
+
+    assert result.returncode == 0, result.stderr
+    assert "built 1.7.3" in result.stdout
+    assert "twine-check" in result.stdout
+    assert "release-upload" in result.stdout
+    assert "Deployed isovar 1.7.3" in result.stdout
+    assert (repo / "isovar" / "__init__.py").read_text() == \
+        '__version__ = "1.7.3"\n'
+    assert _git(repo, "log", "-1", "--pretty=%s").stdout.strip() == \
+        "Bump version to 1.7.3"
+    assert '__version__ = "1.7.3"' in _git(
+        repo, "show", "origin/main:isovar/__init__.py").stdout
+    assert _git(repo, "tag", "--list", "v1.7.3").stdout.strip() == "v1.7.3"
+    assert "refs/tags/v1.7.3" in _git(
+        repo, "ls-remote", "--tags", "origin", "refs/tags/v1.7.3").stdout
+    assert _git(repo, "status", "--porcelain").stdout == ""

--- a/tests/test_release_upload.py
+++ b/tests/test_release_upload.py
@@ -1,0 +1,273 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import io
+import json
+from pathlib import Path
+import subprocess
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+import release_upload
+from release_upload import (
+    ReleaseUploadError,
+    expected_release_filenames,
+    main,
+    pypi_release_filenames,
+    publish_release,
+    upload_distribution,
+    wait_for_release_file,
+)
+
+
+EXPECTED = expected_release_filenames("isovar", "1.7.3")
+PATHS = tuple(Path("dist") / filename for filename in EXPECTED)
+
+
+def test_expected_release_filenames_are_exact_wheel_and_sdist():
+    assert EXPECTED == {
+        "isovar-1.7.3-py3-none-any.whl",
+        "isovar-1.7.3.tar.gz",
+    }
+
+
+def test_pypi_release_filenames_reads_project_release_map(monkeypatch):
+    observed = {}
+
+    def open_url(url, timeout):
+        observed.update(url=url, timeout=timeout)
+        return io.BytesIO(json.dumps({
+            "releases": {
+                "1.7.3": [{"filename": "isovar-1.7.3.tar.gz"}],
+            },
+        }).encode("utf-8"))
+
+    monkeypatch.setattr(release_upload, "urlopen", open_url)
+    monkeypatch.setattr(release_upload, "token_hex", lambda length: "fresh-token")
+
+    assert pypi_release_filenames(
+        "isovar",
+        "1.7.3",
+        json_base_url="https://packages.example/pypi/",
+        request_timeout_seconds=7,
+    ) == {"isovar-1.7.3.tar.gz"}
+    assert observed == {
+        "url": "https://packages.example/pypi/isovar/json?cache_bust=fresh-token",
+        "timeout": 7,
+    }
+
+
+def test_pypi_release_filenames_uses_fresh_url_for_each_poll(monkeypatch):
+    urls = []
+    tokens = iter(["first-token", "second-token"])
+
+    def open_url(url, timeout):
+        urls.append(url)
+        return io.BytesIO(b'{"releases": {}}')
+
+    monkeypatch.setattr(release_upload, "urlopen", open_url)
+    monkeypatch.setattr(release_upload, "token_hex", lambda length: next(tokens))
+
+    pypi_release_filenames("isovar", "1.7.3")
+    pypi_release_filenames("isovar", "1.7.3")
+
+    assert urls == [
+        "https://pypi.org/pypi/isovar/json?cache_bust=first-token",
+        "https://pypi.org/pypi/isovar/json?cache_bust=second-token",
+    ]
+
+
+def test_pypi_release_filenames_treats_missing_project_as_empty(monkeypatch):
+    def open_url(url, timeout):
+        raise HTTPError(url, 404, "Not Found", {}, None)
+
+    monkeypatch.setattr(release_upload, "urlopen", open_url)
+    assert pypi_release_filenames("isovar", "1.7.3") == frozenset()
+
+
+def test_upload_distribution_is_bounded_and_disables_progress(monkeypatch):
+    observed = {}
+
+    def run(command, check, timeout):
+        observed.update(command=command, check=check, timeout=timeout)
+
+    monkeypatch.setattr(subprocess, "run", run)
+    upload_distribution(
+        "dist/isovar-1.7.3.tar.gz",
+        python_executable="release-python",
+        timeout_seconds=17,
+    )
+
+    assert observed == {
+        "command": [
+            "release-python",
+            "-m",
+            "twine",
+            "upload",
+            "--disable-progress-bar",
+            "dist/isovar-1.7.3.tar.gz",
+        ],
+        "check": True,
+        "timeout": 17,
+    }
+
+
+def test_wait_for_release_file_observes_eventual_metadata():
+    responses = iter([set(), {"isovar-1.7.3.tar.gz"}])
+
+    assert wait_for_release_file(
+        "isovar-1.7.3.tar.gz",
+        lambda: next(responses),
+        timeout_seconds=1,
+        poll_seconds=0,
+    )
+
+
+def test_wait_for_release_file_retries_transient_metadata_error():
+    responses = iter([
+        URLError("temporary metadata failure"),
+        {"isovar-1.7.3.tar.gz"},
+    ])
+
+    def fetch_release_filenames():
+        response = next(responses)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    assert wait_for_release_file(
+        "isovar-1.7.3.tar.gz",
+        fetch_release_filenames,
+        timeout_seconds=1,
+        poll_seconds=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "upload_error",
+    [
+        pytest.param(
+            subprocess.TimeoutExpired(["twine", "upload"], timeout=60),
+            id="timeout",
+        ),
+        pytest.param(
+            subprocess.CalledProcessError(1, ["twine", "upload"]),
+            id="nonzero-exit",
+        ),
+    ],
+)
+def test_ambiguous_failure_after_server_acceptance_is_reconciled(upload_error):
+    published = set()
+
+    def fetch_release_filenames():
+        return published
+
+    def upload_file(path):
+        published.add(path.name)
+        raise upload_error
+
+    result = publish_release(
+        PATHS,
+        expected_filenames=EXPECTED,
+        fetch_release_filenames=fetch_release_filenames,
+        upload_file=upload_file,
+        verify_timeout_seconds=0,
+    )
+
+    assert EXPECTED <= result
+
+
+def test_partial_release_uploads_only_missing_file_and_retry_is_safe():
+    wheel = "isovar-1.7.3-py3-none-any.whl"
+    sdist = "isovar-1.7.3.tar.gz"
+    published = {wheel}
+    uploaded = []
+
+    def fetch_release_filenames():
+        return published
+
+    def upload_file(path):
+        uploaded.append(path.name)
+        published.add(path.name)
+
+    for _ in range(2):
+        publish_release(
+            PATHS,
+            expected_filenames=EXPECTED,
+            fetch_release_filenames=fetch_release_filenames,
+            upload_file=upload_file,
+            verify_timeout_seconds=0,
+        )
+
+    assert uploaded == [sdist]
+
+
+def test_failed_upload_without_server_artifact_fails_hard():
+    def upload_file(path):
+        raise subprocess.TimeoutExpired(["twine", "upload", path], timeout=60)
+
+    with pytest.raises(ReleaseUploadError, match="did not publish"):
+        publish_release(
+            PATHS,
+            expected_filenames=EXPECTED,
+            fetch_release_filenames=frozenset,
+            upload_file=upload_file,
+            verify_timeout_seconds=0,
+        )
+
+
+def test_unexpected_distribution_set_is_rejected_before_upload():
+    with pytest.raises(ReleaseUploadError, match="do not match"):
+        publish_release(
+            ["dist/isovar-1.7.3.tar.gz"],
+            expected_filenames=EXPECTED,
+            fetch_release_filenames=frozenset,
+            upload_file=lambda path: None,
+        )
+
+
+def test_duplicate_distribution_basename_is_rejected_before_upload():
+    paths = list(PATHS) + [Path("other") / next(iter(EXPECTED))]
+
+    with pytest.raises(ReleaseUploadError, match="do not match"):
+        publish_release(
+            paths,
+            expected_filenames=EXPECTED,
+            fetch_release_filenames=frozenset,
+            upload_file=lambda path: None,
+        )
+
+
+def test_main_passes_exact_artifact_contract_to_publisher(monkeypatch, capsys):
+    observed = {}
+
+    def publish_release_call(distribution_paths, **kwargs):
+        observed.update(
+            distribution_paths=tuple(distribution_paths),
+            expected_filenames=kwargs["expected_filenames"],
+        )
+        return EXPECTED
+
+    monkeypatch.setattr(release_upload, "publish_release", publish_release_call)
+
+    assert main([
+        "--project", "isovar",
+        "--version", "1.7.3",
+        *[str(path) for path in PATHS],
+    ]) == 0
+    assert observed == {
+        "distribution_paths": tuple(str(path) for path in PATHS),
+        "expected_filenames": EXPECTED,
+    }
+    assert "Verified PyPI release files" in capsys.readouterr().out


### PR DESCRIPTION
Fixes #194.

The first post-#193 deploy exposed that deploy.sh ignored its version argument and attempted to re-upload 1.7.2. This replaces that unsafe path with a guarded release transaction.

Changes:
- validate canonical increasing release versions and bump isovar/__init__.py
- require main/master and a clean tree; reject conflicting local/remote tags
- run lint and tests before mutation, then push the version commit before publication
- build and twine-check an exact wheel/sdist pair
- upload each missing artifact with bounded, PyPI-reconciled retries so timeouts and partial releases are safely resumable
- tag only after PyPI verifies both artifacts; recover interrupted commit and tag pushes
- add 31 focused tests using isolated repositories and mocked PyPI/Twine state

Verification:
- ./lint.sh
- ./test.sh: 268 passed, 94% coverage
- bash -n deploy.sh
- pytest -q tests/test_deploy_script.py tests/test_release_upload.py: 31 passed