### PR TITLE
Include release tooling in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include deploy.sh
+include release_upload.py

--- a/tests/test_source_distribution.py
+++ b/tests/test_source_distribution.py
@@ -1,0 +1,81 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+
+
+ROOT_FILES = (
+    "LICENSE",
+    "MANIFEST.in",
+    "README.md",
+    "deploy.sh",
+    "pyproject.toml",
+    "release_upload.py",
+    "requirements.txt",
+)
+RELEASE_TESTS = (
+    "test_deploy_script.py",
+    "test_release_upload.py",
+)
+
+
+def test_sdist_contains_release_tooling_required_by_release_tests(tmp_path):
+    source_root = Path(__file__).resolve().parents[1]
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    for filename in ROOT_FILES:
+        shutil.copy2(source_root / filename, checkout / filename)
+    shutil.copytree(source_root / "isovar", checkout / "isovar")
+    packaged_tests = checkout / "tests"
+    packaged_tests.mkdir()
+    for filename in RELEASE_TESTS:
+        shutil.copy2(source_root / "tests" / filename, packaged_tests / filename)
+
+    dist_dir = checkout / "dist"
+    dist_dir.mkdir()
+    env = os.environ.copy()
+    for name in tuple(env):
+        if name.startswith("COV_CORE_"):
+            del env[name]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from setuptools.build_meta import build_sdist; "
+            "build_sdist('dist')",
+        ],
+        cwd=checkout,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    archives = tuple(dist_dir.glob("isovar-*.tar.gz"))
+    assert len(archives) == 1
+    with tarfile.open(archives[0], "r:gz") as archive:
+        root = archive.getnames()[0].split("/", 1)[0]
+        names = set(archive.getnames())
+        assert "%s/deploy.sh" % root in names
+        assert "%s/release_upload.py" % root in names
+        assert "%s/tests/test_deploy_script.py" % root in names
+        assert "%s/tests/test_release_upload.py" % root in names
+        deploy_info = archive.getmember("%s/deploy.sh" % root)
+        assert deploy_info.mode & stat.S_IXUSR


### PR DESCRIPTION
Fixes #196.

The 1.7.3 source archive included the release-specific tests but omitted the root files those tests import and copy. Add explicit manifest entries for `deploy.sh` and `release_upload.py`.

The regression test builds a real sdist from an isolated checkout and inspects the archive to require:
- `deploy.sh` and `release_upload.py`
- both packaged release tests
- the executable bit on `deploy.sh`

Verification:
- `./lint.sh`
- `./test.sh`: 269 passed, 94% coverage
- focused artifact test: 1 passed