### PR TITLE
Preserve transcript-compatible RNA assemblies

### DIFF
--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -132,10 +132,11 @@ def greedy_merge_helper(
             continue
         used.add(i)
         used.add(j)
-        if combined.sequence in merged_variant_sequences:
-            existing = merged_variant_sequences[combined.sequence]
+        combined_key = (combined.prefix, combined.alt, combined.suffix)
+        if combined_key in merged_variant_sequences:
+            existing = merged_variant_sequences[combined_key]
             combined = combined.add_reads(existing.reads)
-        merged_variant_sequences[combined.sequence] = combined
+        merged_variant_sequences[combined_key] = combined
 
     unmerged = [
         variant_sequences[k]
@@ -148,20 +149,41 @@ def greedy_merge_helper(
 
 def greedy_merge(
         variant_sequences,
-        min_overlap_size=MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE):
+        min_overlap_size=MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE,
+        preserve_intermediate_candidates=False):
     """
     Greedily merge overlapping sequences into longer sequences.
 
     Accepts a collection of VariantSequence objects and returns another
     collection of elongated variant sequences. The reads field of the
     returned VariantSequence object will contain reads which
-    only partially overlap the full sequence.
+    only partially overlap the full sequence. When
+    ``preserve_intermediate_candidates`` is true, the result also contains
+    the input and every intermediate assembly candidate, with reads from
+    exact duplicates combined.
     """
+    variant_sequences = list(variant_sequences)
+    intermediate_candidates = {}
+
+    def preserve_candidates(candidates):
+        for candidate in candidates:
+            key = (candidate.prefix, candidate.alt, candidate.suffix)
+            if key in intermediate_candidates:
+                candidate = intermediate_candidates[key].add_reads(
+                    candidate.reads)
+            intermediate_candidates[key] = candidate
+
+    if preserve_intermediate_candidates:
+        preserve_candidates(variant_sequences)
     merged_any = True
     while merged_any:
         variant_sequences, merged_any = greedy_merge_helper(
             variant_sequences,
             min_overlap_size=min_overlap_size)
+        if preserve_intermediate_candidates and merged_any:
+            preserve_candidates(variant_sequences)
+    if preserve_intermediate_candidates:
+        return list(intermediate_candidates.values())
     return variant_sequences
 
 
@@ -207,13 +229,36 @@ def collapse_substrings(variant_sequences):
     ]
 
 
+def merge_identical_sequences(variant_sequences):
+    """Union reads for exact candidates without discarding substrings.
+
+    Distinct prefix/alt/suffix triples must remain distinct until transcript
+    compatibility is known. Exact duplicates, including duplicates created by
+    coverage trimming or retained assembly history, carry no extra sequence
+    information and can be combined safely.
+    """
+    sequences_by_parts = {}
+    for variant_sequence in variant_sequences:
+        key = (
+            variant_sequence.prefix,
+            variant_sequence.alt,
+            variant_sequence.suffix,
+        )
+        if key in sequences_by_parts:
+            variant_sequence = sequences_by_parts[key].add_reads(
+                variant_sequence.reads)
+        sequences_by_parts[key] = variant_sequence
+    return list(sequences_by_parts.values())
+
+
 DEFAULT_MAX_ASSEMBLY_SEQUENCES = 1000
 
 
 def iterative_overlap_assembly(
         variant_sequences,
         min_overlap_size=MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE,
-        max_assembly_sequences=DEFAULT_MAX_ASSEMBLY_SEQUENCES):
+        max_assembly_sequences=DEFAULT_MAX_ASSEMBLY_SEQUENCES,
+        preserve_candidate_sequences=False):
     """
     Assembles longer sequences from reads centered on a variant by
     merging all pairs of overlapping sequences and collapsing
@@ -230,11 +275,19 @@ def iterative_overlap_assembly(
         substring collapse, skip the O(n^2)-per-round greedy merge and
         return sequences sorted by read support. Set to None to disable.
 
+    preserve_candidate_sequences : bool
+        Return the input and intermediate sequences as well as final assembled
+        sequences. Translation pipelines must enable this: a contained or
+        intermediate candidate can match a reference transcript even when its
+        longer assembly cannot. Exact duplicate candidates are still merged.
+
     Returns a list of variant sequences, sorted by decreasing read support.
     """
+    variant_sequences = list(variant_sequences)
     if len(variant_sequences) <= 1:
         return variant_sequences
 
+    input_variant_sequences = variant_sequences
     n_before_collapse = len(variant_sequences)
     variant_sequences = collapse_substrings(variant_sequences)
     n_after_collapse = len(variant_sequences)
@@ -251,8 +304,20 @@ def iterative_overlap_assembly(
             n_after_collapse,
             max_assembly_sequences)
     else:
-        variant_sequences = greedy_merge(variant_sequences, min_overlap_size)
+        variant_sequences = greedy_merge(
+            variant_sequences,
+            min_overlap_size,
+            preserve_intermediate_candidates=preserve_candidate_sequences)
+
+    if preserve_candidate_sequences:
+        variant_sequences = merge_identical_sequences(
+            input_variant_sequences + variant_sequences)
 
     return list(sorted(
         variant_sequences,
-        key=lambda seq: -len(seq.reads)))
+        key=lambda seq: (
+            -len(seq.reads),
+            seq.prefix,
+            seq.alt,
+            seq.suffix,
+        )))

--- a/isovar/variant_sequence_creator.py
+++ b/isovar/variant_sequence_creator.py
@@ -29,8 +29,9 @@ logger = get_logger(__name__)
 
 class VariantSequenceCreator(object):
     """
-    Assembler is used to assemble a set of AlleleReads into a smaller set of
-    VariantSequence objects based on overlap of read sequences.
+    Assemble AlleleReads into candidate VariantSequence objects based on
+    overlap, retaining independently supported contained candidates for
+    reference matching.
     """
     def __init__(
             self,
@@ -126,7 +127,8 @@ class VariantSequenceCreator(object):
                 n_surrounding_nucleotides // 2)
             variant_sequences = iterative_overlap_assembly(
                 variant_sequences,
-                min_overlap_size=min_overlap_size)
+                min_overlap_size=min_overlap_size,
+                preserve_candidate_sequences=True)
 
         if variant_sequences:
             logger.info(

--- a/isovar/variant_sequence_helpers.py
+++ b/isovar/variant_sequence_helpers.py
@@ -16,7 +16,7 @@ from reads overlapping a variant locus.
 """
 
 from .allele_read_helpers import group_unique_sequences
-from .assembly import collapse_substrings
+from .assembly import merge_identical_sequences
 from .logging import get_logger
 from .variant_sequence import VariantSequence
 
@@ -143,8 +143,10 @@ def filter_variant_sequences_by_length(
 
 def trim_variant_sequences(variant_sequences, min_variant_sequence_coverage):
     """
-    Trim VariantSequences to desired coverage and then combine any
-    subsequences which get generated.
+    Trim VariantSequences to desired coverage and combine exact duplicates.
+
+    Contained but non-identical candidates remain separate because reference
+    compatibility is not known at this stage.
 
     Parameters
     ----------
@@ -168,14 +170,15 @@ def trim_variant_sequences(variant_sequences, min_variant_sequence_coverage):
         )
         if len(trimmed) > 0
     ]
-    collapsed_variant_sequences = collapse_substrings(trimmed_variant_sequences)
-    n_after_trimming = len(collapsed_variant_sequences)
+    trimmed_variant_sequences = merge_identical_sequences(
+        trimmed_variant_sequences)
+    n_after_trimming = len(trimmed_variant_sequences)
     logger.info(
         "Kept %d/%d variant sequences after read coverage trimming to >=%dx",
         n_after_trimming,
         n_total,
         min_variant_sequence_coverage)
-    return collapsed_variant_sequences
+    return trimmed_variant_sequences
 
 
 def filter_variant_sequences(

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import random
+from itertools import permutations
 from time import time
 
 from isovar.read_collector import ReadCollector
@@ -21,7 +22,8 @@ from isovar.assembly import (
     iterative_overlap_assembly,
     greedy_merge,
     greedy_merge_helper,
-    collapse_substrings
+    collapse_substrings,
+    merge_identical_sequences,
 )
 
 from pyensembl import ensembl_grch38
@@ -201,6 +203,108 @@ def test_collapse_substrings_absorbs_into_first_only():
     eq_(n_carrying_short, 1,
         "Short read 'S' should only be absorbed into one longer sequence, got %d: %s" % (
             n_carrying_short, results))
+
+
+def test_merge_identical_sequences_preserves_distinct_substrings():
+    longer = VariantSequence(
+        prefix="AAA", alt="C", suffix="GGG", reads={"long"})
+    shorter = VariantSequence(
+        prefix="AA", alt="C", suffix="GG", reads={"short"})
+    duplicate_longer = VariantSequence(
+        prefix="AAA", alt="C", suffix="GGG", reads={"duplicate"})
+    first_variant_position = VariantSequence(
+        prefix="T", alt="C", suffix="CG", reads={"first-position"})
+    second_variant_position = VariantSequence(
+        prefix="TC", alt="C", suffix="G", reads={"second-position"})
+
+    results = merge_identical_sequences([
+        longer,
+        shorter,
+        duplicate_longer,
+        first_variant_position,
+        second_variant_position,
+    ])
+
+    eq_(first_variant_position.sequence, second_variant_position.sequence)
+    eq_(len(results), 4)
+    by_parts = {
+        (result.prefix, result.alt, result.suffix): result
+        for result in results
+    }
+    eq_(by_parts[(longer.prefix, longer.alt, longer.suffix)].reads,
+        {"long", "duplicate"})
+    eq_(by_parts[(shorter.prefix, shorter.alt, shorter.suffix)].reads,
+        {"short"})
+    eq_(by_parts[("T", "C", "CG")].reads, {"first-position"})
+    eq_(by_parts[("TC", "C", "G")].reads, {"second-position"})
+
+
+def test_greedy_merge_helper_preserves_distinct_variant_positions():
+    # Both accepted pairs assemble the same full bases (TCCG), but place the
+    # variant C at different positions. They are not interchangeable cDNA
+    # candidates and therefore must not be deduplicated by ``sequence`` alone.
+    candidates = [
+        VariantSequence("T", alt="C", suffix="", reads={"left-1"}),
+        VariantSequence("", alt="C", suffix="CG", reads={"right-1"}),
+        VariantSequence("TC", alt="C", suffix="", reads={"left-2"}),
+        VariantSequence("", alt="C", suffix="G", reads={"right-2"}),
+    ]
+
+    results, merged_any = greedy_merge_helper(candidates, min_overlap_size=1)
+
+    assert merged_any
+    eq_(len(results), 2)
+    eq_({(result.prefix, result.alt, result.suffix) for result in results},
+        {("T", "C", "CG"), ("TC", "C", "G")})
+
+
+def test_candidate_preserving_assembly_keeps_nested_sequences():
+    prefixes = ("AAA", "GGGAAA", "CCCGGGAAA", "TTTCCCGGGAAA")
+    candidates = [
+        VariantSequence(prefix, alt="C", suffix="AAAA", reads={prefix})
+        for prefix in prefixes
+    ]
+
+    expected = None
+    # Exercise both the normal merge path and the assembly-size safety cutoff.
+    for max_assembly_sequences in (None, 0):
+        for ordered_candidates in permutations(candidates):
+            results = iterative_overlap_assembly(
+                ordered_candidates,
+                min_overlap_size=1,
+                max_assembly_sequences=max_assembly_sequences,
+                preserve_candidate_sequences=True)
+            observed = {
+                (result.prefix, result.alt, result.suffix): result.reads
+                for result in results
+            }
+            if expected is None:
+                expected = observed
+            eq_(observed, expected)
+
+    eq_({parts[0] for parts in expected}, set(prefixes))
+    eq_(expected[(prefixes[-1], "C", "AAAA")], set(prefixes))
+
+
+def test_greedy_merge_preserves_generator_inputs_and_intermediate_candidates():
+    candidates = [
+        VariantSequence("AAAA", alt="C", suffix="G", reads={"left"}),
+        VariantSequence("AA", alt="C", suffix="GGG", reads={"middle"}),
+        VariantSequence("A", alt="C", suffix="GGGGG", reads={"right"}),
+    ]
+
+    results = greedy_merge(
+        (candidate for candidate in candidates),
+        min_overlap_size=1,
+        preserve_intermediate_candidates=True)
+    by_parts = {
+        (result.prefix, result.alt, result.suffix): result.reads
+        for result in results
+    }
+
+    eq_(len(by_parts), 5)
+    eq_(by_parts[("AA", "C", "GGGGG")], {"middle", "right"})
+    eq_(by_parts[("AAAA", "C", "GGGGG")], {"left", "middle", "right"})
 
 
 def test_assembly_of_many_subsequences():

--- a/tests/test_variant_orf.py
+++ b/tests/test_variant_orf.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from varcode import Variant
 
 from isovar.variant_orf import (
@@ -23,6 +24,7 @@ from isovar.reference_context import ReferenceContext
 from isovar.allele_read import AlleleRead
 from isovar.dna import reverse_complement_dna
 from isovar.protein_sequence_creator import ProteinSequenceCreator
+from isovar.variant_sequence_creator import VariantSequenceCreator
 from isovar.variant_sequence_helpers import filter_variant_sequences
 
 from .common import eq_ 
@@ -243,6 +245,80 @@ def test_filter_variant_sequences_defers_reference_compatibility():
     eq_(set(filtered), {compatible_short, incompatible_long})
     eq_(len(translations), 1)
     eq_(translations[0].untrimmed_variant_sequence, compatible_short)
+
+
+@pytest.mark.parametrize("strand", ["+", "-"])
+@pytest.mark.parametrize("variant_sequence_assembly", [True, False])
+def test_nested_assemblies_reach_reference_matching_independently(
+        strand,
+        variant_sequence_assembly):
+    """Regression test for #198 through sequence creation and translation."""
+    variant = Variant("1", 100, "G", "C", "GRCh38")
+    cdna_prefixes = ("AAA", "GGGAAA", "CCCGGGAAA", "TTTCCCGGGAAA")
+    if strand == "+":
+        genomic_prefixes = cdna_prefixes
+        genomic_suffixes = ("A" * 8,) * len(cdna_prefixes)
+    else:
+        genomic_prefixes = ("T" * 8,) * len(cdna_prefixes)
+        genomic_suffixes = tuple(
+            reverse_complement_dna(prefix) for prefix in cdna_prefixes)
+    reads = [
+        AlleleRead(
+            prefix=prefix,
+            allele=variant.alt,
+            suffix=suffix,
+            name="%s_%s_%d" % (strand, cdna_prefix, i))
+        for cdna_prefix, prefix, suffix in zip(
+            cdna_prefixes, genomic_prefixes, genomic_suffixes)
+        for i in range(2)
+    ]
+    reference_context = ReferenceContext(
+        strand=strand,
+        sequence_before_variant_locus="A" * len(cdna_prefixes[-1]),
+        sequence_at_variant_locus=(
+            variant.ref if strand == "+"
+            else reverse_complement_dna(variant.ref)),
+        sequence_after_variant_locus="A" * 8,
+        offset_to_first_complete_codon=0,
+        contains_start_codon=False,
+        overlaps_start_codon=False,
+        contains_five_prime_utr=False,
+        amino_acids_before_variant="",
+        variant=variant,
+        transcripts=())
+
+    sequence_creator = VariantSequenceCreator(
+        min_variant_sequence_coverage=2,
+        # VariantSequenceCreator divides this budget approximately equally
+        # between both sides of the variant. Leave enough room for the full
+        # longest prefix so this test exercises assembly rather than clipping.
+        preferred_sequence_length=len(cdna_prefixes[-1]) * 2 + 1,
+        variant_sequence_assembly=variant_sequence_assembly,
+        min_assembly_overlap_size=1)
+    variant_sequences = sequence_creator.reads_to_variant_sequences(
+        variant=variant,
+        reads=reads)
+    protein_creator = ProteinSequenceCreator(
+        protein_sequence_length=8,
+        min_variant_sequence_coverage=2,
+        min_transcript_prefix_length=3,
+        max_transcript_mismatches=2)
+    translations = protein_creator.all_pairs_translations(
+        variant_sequences=variant_sequences,
+        reference_contexts=[reference_context])
+
+    if strand == "+":
+        observed_candidates = {sequence.prefix for sequence in variant_sequences}
+        compatible_sequence = "AAA"
+    else:
+        observed_candidates = {sequence.suffix for sequence in variant_sequences}
+        compatible_sequence = reverse_complement_dna("AAA")
+    eq_(observed_candidates,
+        set(genomic_prefixes if strand == "+" else genomic_suffixes))
+    eq_(len(translations), 1)
+    translated_sequence = translations[0].untrimmed_variant_sequence
+    eq_(translated_sequence.prefix if strand == "+" else translated_sequence.suffix,
+        compatible_sequence)
 
 
 def test_protein_sequence_creator_translates_coding_deletion():

--- a/tests/test_variant_sequences.py
+++ b/tests/test_variant_sequences.py
@@ -468,6 +468,49 @@ def test_trim_variant_sequences_distinguishes_deletion_from_degenerate():
     eq_(trimmed, [covered_deletion])
 
 
+def test_trim_variant_sequences_preserves_supported_substrings():
+    shorter = _variant_sequence("AA", "C", "GG", 2, "shorter")
+    longer = _variant_sequence("AAA", "C", "GGG", 2, "longer")
+
+    trimmed = trim_variant_sequences(
+        [longer, shorter],
+        min_variant_sequence_coverage=2)
+
+    eq_(set(trimmed), {longer, shorter})
+
+
+def test_trim_variant_sequences_merges_only_exact_trimmed_duplicates():
+    long_read = AlleleRead(
+        prefix="TAA", allele="C", suffix="GG", name="long")
+    inner_read = AlleleRead(
+        prefix="AA", allele="C", suffix="GG", name="inner")
+    already_trimmed_reads = [
+        AlleleRead(
+            prefix="AA", allele="C", suffix="GG", name="exact_%d" % i)
+        for i in range(2)
+    ]
+    needs_trimming = VariantSequence(
+        prefix="TAA",
+        alt="C",
+        suffix="GG",
+        reads={long_read, inner_read})
+    already_trimmed = VariantSequence(
+        prefix="AA",
+        alt="C",
+        suffix="GG",
+        reads=already_trimmed_reads)
+
+    trimmed = trim_variant_sequences(
+        [needs_trimming, already_trimmed],
+        min_variant_sequence_coverage=2)
+
+    eq_(len(trimmed), 1)
+    eq_((trimmed[0].prefix, trimmed[0].alt, trimmed[0].suffix),
+        ("AA", "C", "GG"))
+    eq_(trimmed[0].reads,
+        {long_read, inner_read}.union(already_trimmed_reads))
+
+
 def test_filter_by_length_distinguishes_deletion_from_degenerate_sequence():
     # a deletion and a degenerate sequence both have an empty alt, so only
     # total length can tell them apart. The deletion is shorter and better


### PR DESCRIPTION
Fixes #198.

## Why

Isovar currently collapses contained RNA assemblies before it knows whether each candidate matches a reference transcript. A longer, better-supported superstring can be reference-incompatible while an independently supported contained candidate is the only translatable sequence. The same information-loss risk exists after coverage trimming.

This matters to the intended Isovar model: tumor RNA can imply multiple coding sequences because of sequencing error, splice diversity, and tumor heterogeneity, and Vaxrank cannot recover a candidate once Isovar discards it. See the primary PGV pipeline description: https://doi.org/10.3389/fimmu.2017.01807

## What changed

- retain independently supported input and intermediate assembly candidates in the translation pipeline
- continue building longer superstrings and transferring supporting reads
- replace post-trim substring collapse with exact `(prefix, alt, suffix)` deduplication
- deduplicate greedy merge results by the same exact identity, not concatenated bases, so repeated sequence cannot erase a distinct variant position
- keep legacy compact output as the default for direct low-level assembly callers; `VariantSequenceCreator` explicitly selects the safe translation behavior
- bound retained assembly history to unique candidate identities rather than accumulating repeated round snapshots

## Verification

- `./lint.sh`
- `./test.sh` — 279 passed, 94% coverage
- regression runs through `VariantSequenceCreator` and translation on both transcript strands, with assembly enabled and disabled
- all 24 input permutations, normal assembly and safety-cutoff paths
- generator inputs, intermediate assemblies, exact post-trim deduplication, and distinct variant offsets in identical bases
- mutation checks confirm the regressions fail if creator preservation, trim-stage preservation, intermediate retention, or exact candidate identity is reverted
- real BAM smoke test: 20 initial candidates reduced to one supported consensus in 6 ms