### PR TITLE
Update CI actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
Fixes #201.

## Changes

- update `actions/checkout` from v4 to v7
- update `actions/setup-python` from v5 to v7

Both current v7 majors declare the Node 24 runtime. The setup-python v7 removal of the `pip-install` input does not affect this workflow because it is not used.

Official releases:

- https://github.com/actions/checkout/releases/tag/v7.0.1
- https://github.com/actions/setup-python/releases/tag/v7.0.0

## Verification

- workflow YAML parses and resolves both expected v7 pins
- `./lint.sh` passes
- `./test.sh` passes: 279 tests, 94% coverage
- this PR CI will verify the actual hosted runner behavior across Python 3.9, 3.10, and 3.11 and confirm the Node 20 annotations are gone