### PR TITLE
Use one Python interpreter throughout release gates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include deploy.sh
+include lint.sh
 include release_upload.py
+include test.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -42,10 +42,33 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-PYTHON="${PYTHON:-python3}"
-if [[ -x ".venv/bin/python" ]]; then
-  PYTHON=".venv/bin/python"
-fi
+resolve_python() {
+  local candidate
+  local resolved_python
+  if [[ -n "${PYTHON:-}" ]]; then
+    candidate="${PYTHON}"
+  elif [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
+    candidate="${VIRTUAL_ENV}/bin/python"
+  elif [[ -x ".venv/bin/python" ]]; then
+    candidate=".venv/bin/python"
+  else
+    candidate="python3"
+  fi
+
+  if ! resolved_python="$(command -v "${candidate}" 2>/dev/null)" || \
+      [[ ! -f "${resolved_python}" || ! -x "${resolved_python}" ]]; then
+    echo "Python interpreter not found or not executable: ${candidate}" >&2
+    exit 1
+  fi
+  if [[ "${resolved_python}" != /* ]]; then
+    resolved_python="${PWD}/${resolved_python#./}"
+  fi
+  PYTHON="${resolved_python}"
+  export PYTHON
+}
+
+resolve_python
+echo "Using Python interpreter: ${PYTHON}"
 
 CURRENT_VERSION="$(
   "$PYTHON" - <<'PY'

--- a/lint.sh
+++ b/lint.sh
@@ -1,6 +1,32 @@
-#!/bin/bash
-set -o errexit
+#!/usr/bin/env bash
+set -euo pipefail
 
-ruff check isovar/ tests/
+resolve_python() {
+  local candidate
+  local resolved_python
+  if [[ -n "${PYTHON:-}" ]]; then
+    candidate="${PYTHON}"
+  elif [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
+    candidate="${VIRTUAL_ENV}/bin/python"
+  elif [[ -x ".venv/bin/python" ]]; then
+    candidate=".venv/bin/python"
+  else
+    candidate="python3"
+  fi
+
+  if ! resolved_python="$(command -v "${candidate}" 2>/dev/null)" || \
+      [[ ! -f "${resolved_python}" || ! -x "${resolved_python}" ]]; then
+    echo "Python interpreter not found or not executable: ${candidate}" >&2
+    exit 1
+  fi
+  if [[ "${resolved_python}" != /* ]]; then
+    resolved_python="${PWD}/${resolved_python#./}"
+  fi
+  PYTHON="${resolved_python}"
+  export PYTHON
+}
+
+resolve_python
+"${PYTHON}" -m ruff check isovar/ tests/
 
 echo 'Passes ruff check'

--- a/test.sh
+++ b/test.sh
@@ -18,6 +18,33 @@ TEST_SH_MAX="${TEST_SH_MAX:-0}"
 
 log() { printf '[test.sh] %s\n' "$*" >&2; }
 
+resolve_python() {
+    local candidate
+    local resolved_python
+    if [[ -n "${PYTHON:-}" ]]; then
+        candidate="${PYTHON}"
+    elif [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
+        candidate="${VIRTUAL_ENV}/bin/python"
+    elif [[ -x ".venv/bin/python" ]]; then
+        candidate=".venv/bin/python"
+    else
+        candidate="python3"
+    fi
+
+    if ! resolved_python="$(command -v "${candidate}" 2>/dev/null)" || \
+        [[ ! -f "${resolved_python}" || ! -x "${resolved_python}" ]]; then
+        log "Python interpreter not found or not executable: ${candidate}"
+        exit 1
+    fi
+    if [[ "${resolved_python}" != /* ]]; then
+        resolved_python="${PWD}/${resolved_python#./}"
+    fi
+    PYTHON="${resolved_python}"
+    export PYTHON
+}
+
+resolve_python
+
 case "$(uname -s)" in
     Darwin) OS=macos ;;
     Linux)  OS=linux ;;
@@ -96,13 +123,14 @@ if (( TEST_SH_MAX > 0 && WORKERS > TEST_SH_MAX )); then WORKERS=$TEST_SH_MAX; fi
 if (( WORKERS < TEST_SH_MIN )); then WORKERS=$TEST_SH_MIN; fi
 
 XDIST_FLAGS=()
-if python -c "import xdist" 2>/dev/null; then
+if "${PYTHON}" -c "import xdist" 2>/dev/null; then
     XDIST_FLAGS=(-n "$WORKERS")
-    log "platform=${OS} cpus=${CPUS} cpu_cap=${CPU_CAP} ${mem_note} per_worker=${PER_WORKER_GB}GB"
+    log "python=${PYTHON} platform=${OS} cpus=${CPUS} cpu_cap=${CPU_CAP} ${mem_note} per_worker=${PER_WORKER_GB}GB"
     log "workers=${WORKERS} → exec pytest -n ${WORKERS} --cov=isovar/ --cov-report=term-missing tests $*"
 else
-    log "platform=${OS} cpus=${CPUS} (pytest-xdist not installed; running serial)"
+    log "python=${PYTHON} platform=${OS} cpus=${CPUS} (pytest-xdist not installed; running serial)"
     log "→ exec pytest --cov=isovar/ --cov-report=term-missing tests $*"
 fi
 
-exec pytest "${XDIST_FLAGS[@]}" --cov=isovar/ --cov-report=term-missing tests "$@"
+exec "${PYTHON}" -m pytest \
+    "${XDIST_FLAGS[@]}" --cov=isovar/ --cov-report=term-missing tests "$@"

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -48,7 +48,8 @@ def _release_repo(tmp_path):
     package_dir.mkdir(parents=True)
     shutil.copy(source_root / "deploy.sh", repo / "deploy.sh")
     (package_dir / "__init__.py").write_text('__version__ = "1.7.2"\n')
-    (repo / ".gitignore").write_text("__pycache__/\nbuild/\ndist/\n")
+    (repo / ".gitignore").write_text(
+        "__pycache__/\n.venv/\nbuild/\ndist/\n")
     for script_name, output in (("lint.sh", "lint-gate"), ("test.sh", "test-gate")):
         script = repo / script_name
         script.write_text("#!/bin/sh\necho %s\n" % output)
@@ -79,8 +80,29 @@ def _deploy(repo, *args, env_updates=None):
             del env[name]
     env["PYTHON"] = sys.executable
     if env_updates:
-        env.update(env_updates)
+        for name, value in env_updates.items():
+            if value is None:
+                env.pop(name, None)
+            else:
+                env[name] = value
     return _run(["bash", "deploy.sh"] + list(args), cwd=repo, env=env)
+
+
+def _python_symlink(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.symlink_to(sys.executable)
+    return path
+
+
+def _record_gate_pythons(repo):
+    for script_name in ("lint.sh", "test.sh"):
+        script = repo / script_name
+        script.write_text(
+            "#!/bin/sh\nprintf '%s\\n' \"$PYTHON\" >> \"$GATE_PYTHON_LOG\"\n")
+        script.chmod(0o755)
+    _git(repo, "add", "lint.sh", "test.sh")
+    _git(repo, "commit", "-m", "Record gate interpreters")
+    _git(repo, "push", "origin", "main")
 
 
 def _fake_release_python(tmp_path):
@@ -126,6 +148,138 @@ def test_deploy_dry_run_validates_without_mutating(tmp_path):
         '__version__ = "1.7.2"\n'
     assert _git(repo, "rev-list", "--count", "HEAD").stdout.strip() == "1"
     assert _git(repo, "status", "--porcelain").stdout == ""
+
+
+def test_deploy_explicit_python_overrides_virtualenv_and_repo_venv(tmp_path):
+    repo = _release_repo(tmp_path)
+    _record_gate_pythons(repo)
+    explicit_python = _python_symlink(tmp_path / "explicit python")
+    active_venv = tmp_path / "active-venv"
+    _python_symlink(active_venv / "bin" / "python")
+    _python_symlink(repo / ".venv" / "bin" / "python")
+    gate_log = tmp_path / "gate-python.log"
+
+    result = _deploy(
+        repo,
+        "--dry-run",
+        env_updates={
+            "PYTHON": str(explicit_python),
+            "VIRTUAL_ENV": str(active_venv),
+            "GATE_PYTHON_LOG": str(gate_log),
+        })
+
+    assert result.returncode == 0, result.stderr
+    assert gate_log.read_text().splitlines() == [
+        str(explicit_python),
+        str(explicit_python),
+    ]
+
+
+def test_deploy_active_virtualenv_overrides_repo_venv(tmp_path):
+    repo = _release_repo(tmp_path)
+    _record_gate_pythons(repo)
+    active_python = _python_symlink(
+        tmp_path / "active-venv" / "bin" / "python")
+    _python_symlink(repo / ".venv" / "bin" / "python")
+    gate_log = tmp_path / "gate-python.log"
+
+    result = _deploy(
+        repo,
+        "--dry-run",
+        env_updates={
+            "PYTHON": None,
+            "VIRTUAL_ENV": str(active_python.parents[1]),
+            "GATE_PYTHON_LOG": str(gate_log),
+        })
+
+    assert result.returncode == 0, result.stderr
+    assert gate_log.read_text().splitlines() == [
+        str(active_python),
+        str(active_python),
+    ]
+
+
+def test_deploy_repo_venv_overrides_path_python(tmp_path):
+    repo = _release_repo(tmp_path)
+    _record_gate_pythons(repo)
+    repo_python = _python_symlink(repo / ".venv" / "bin" / "python")
+    path_bin = tmp_path / "path-bin"
+    _python_symlink(path_bin / "python3")
+    gate_log = tmp_path / "gate-python.log"
+
+    result = _deploy(
+        repo,
+        "--dry-run",
+        env_updates={
+            "PYTHON": None,
+            "VIRTUAL_ENV": None,
+            "PATH": "%s%s%s" % (
+                path_bin,
+                os.pathsep,
+                os.environ["PATH"],
+            ),
+            "GATE_PYTHON_LOG": str(gate_log),
+        })
+
+    assert result.returncode == 0, result.stderr
+    assert gate_log.read_text().splitlines() == [
+        str(repo_python),
+        str(repo_python),
+    ]
+
+
+def test_deploy_falls_back_to_python3_from_path(tmp_path):
+    repo = _release_repo(tmp_path)
+    _record_gate_pythons(repo)
+    path_bin = tmp_path / "path-bin"
+    path_python = _python_symlink(path_bin / "python3")
+    gate_log = tmp_path / "gate-python.log"
+
+    result = _deploy(
+        repo,
+        "--dry-run",
+        env_updates={
+            "PYTHON": None,
+            "VIRTUAL_ENV": None,
+            "PATH": "%s%s%s" % (
+                path_bin,
+                os.pathsep,
+                os.environ["PATH"],
+            ),
+            "GATE_PYTHON_LOG": str(gate_log),
+        })
+
+    assert result.returncode == 0, result.stderr
+    assert gate_log.read_text().splitlines() == [
+        str(path_python),
+        str(path_python),
+    ]
+
+
+@pytest.mark.parametrize("invalid_python_kind", [
+    "missing",
+    "not-executable",
+    "directory",
+])
+def test_deploy_rejects_invalid_explicit_python_without_fallback(
+        tmp_path,
+        invalid_python_kind):
+    repo = _release_repo(tmp_path)
+    invalid_python = tmp_path / "invalid-python"
+    if invalid_python_kind == "not-executable":
+        invalid_python.write_text("#!/bin/sh\nexit 0\n")
+    elif invalid_python_kind == "directory":
+        invalid_python.mkdir()
+
+    result = _deploy(
+        repo,
+        "--dry-run",
+        env_updates={"PYTHON": str(invalid_python)})
+
+    assert result.returncode == 1
+    assert "Python interpreter not found or not executable" in result.stderr
+    assert str(invalid_python) in result.stderr
+    assert "lint-gate" not in result.stdout
 
 
 def test_deploy_rejects_non_release_branch_before_gates(tmp_path):

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -1,0 +1,163 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fake_python(python_path):
+    python_path.parent.mkdir(parents=True, exist_ok=True)
+    python_path.write_text("""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$PYTHON_INVOCATION_LOG"
+if [[ "${1:-}" == "-c" && "${2:-}" == "import xdist" ]]; then
+    exit "${XDIST_IMPORT_STATUS:-0}"
+fi
+exit 0
+""")
+    python_path.chmod(0o755)
+    return python_path
+
+
+def _path_traps(tmp_path):
+    trap_dir = tmp_path / "path-traps"
+    trap_dir.mkdir()
+    for command_name in ("python", "python3", "pytest", "ruff"):
+        command_path = trap_dir / command_name
+        command_path.write_text("""#!/bin/sh
+printf '%s\\n' "$0 $*" >> "$PATH_TRAP_LOG"
+exit 97
+""")
+        command_path.chmod(0o755)
+    return trap_dir
+
+
+def _run_gate(tmp_path, script_name, *args, env_updates=None):
+    script_path = tmp_path / script_name
+    shutil.copy2(SOURCE_ROOT / script_name, script_path)
+    env = os.environ.copy()
+    env.update({
+        "PATH": "%s%s%s" % (
+            _path_traps(tmp_path),
+            os.pathsep,
+            env["PATH"],
+        ),
+        "PATH_TRAP_LOG": str(tmp_path / "path-trap.log"),
+        "PYTHON": str(_fake_python(tmp_path / "selected python")),
+        "PYTHON_INVOCATION_LOG": str(tmp_path / "python-invocations.log"),
+        "TEST_SH_MAX": "1",
+        "TEST_SH_MIN": "1",
+    })
+    if env_updates:
+        for name, value in env_updates.items():
+            if value is None:
+                env.pop(name, None)
+            else:
+                env[name] = value
+    result = subprocess.run(
+        ["bash", str(script_path), *args],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    invocation_log = tmp_path / "python-invocations.log"
+    invocations = (
+        invocation_log.read_text().splitlines()
+        if invocation_log.exists()
+        else [])
+    return result, invocations, tmp_path / "path-trap.log"
+
+
+def test_lint_uses_selected_python_module_not_path_ruff(tmp_path):
+    result, invocations, trap_log = _run_gate(tmp_path, "lint.sh")
+
+    assert result.returncode == 0, result.stderr
+    assert invocations == ["-m ruff check isovar/ tests/"]
+    assert not trap_log.exists()
+
+
+@pytest.mark.parametrize(
+    "script_name, expected_invocations",
+    [
+        ("lint.sh", ["-m ruff check isovar/ tests/"]),
+        ("test.sh", [
+            "-c import xdist",
+            "-m pytest -n 1 --cov=isovar/ --cov-report=term-missing tests",
+        ]),
+    ],
+)
+@pytest.mark.parametrize("environment", ["active-venv", "repo-venv"])
+def test_gate_resolves_virtualenv_python_when_python_is_unset(
+        tmp_path,
+        script_name,
+        expected_invocations,
+        environment):
+    if environment == "active-venv":
+        venv = tmp_path / "active venv"
+        env_updates = {
+            "PYTHON": None,
+            "VIRTUAL_ENV": str(venv),
+        }
+    else:
+        venv = tmp_path / ".venv"
+        env_updates = {
+            "PYTHON": None,
+            "VIRTUAL_ENV": None,
+        }
+    selected_python = _fake_python(venv / "bin" / "python")
+
+    result, invocations, trap_log = _run_gate(
+        tmp_path,
+        script_name,
+        env_updates=env_updates)
+
+    assert result.returncode == 0, result.stderr
+    assert invocations == expected_invocations
+    if script_name == "test.sh":
+        assert "python=%s" % selected_python in result.stderr
+    assert not trap_log.exists()
+
+
+@pytest.mark.parametrize(
+    "xdist_import_status, expected_pytest_invocation",
+    [
+        ("0", "-m pytest -n 1 --cov=isovar/ --cov-report=term-missing "
+              "tests selected-test"),
+        ("1", "-m pytest --cov=isovar/ --cov-report=term-missing "
+              "tests selected-test"),
+    ],
+)
+def test_test_gate_uses_same_python_for_plugin_probe_and_pytest(
+        tmp_path,
+        xdist_import_status,
+        expected_pytest_invocation):
+    result, invocations, trap_log = _run_gate(
+        tmp_path,
+        "test.sh",
+        "selected-test",
+        env_updates={"XDIST_IMPORT_STATUS": xdist_import_status})
+
+    assert result.returncode == 0, result.stderr
+    assert invocations == [
+        "-c import xdist",
+        expected_pytest_invocation,
+    ]
+    assert not trap_log.exists()

--- a/tests/test_source_distribution.py
+++ b/tests/test_source_distribution.py
@@ -25,12 +25,15 @@ ROOT_FILES = (
     "MANIFEST.in",
     "README.md",
     "deploy.sh",
+    "lint.sh",
     "pyproject.toml",
     "release_upload.py",
     "requirements.txt",
+    "test.sh",
 )
 RELEASE_TESTS = (
     "test_deploy_script.py",
+    "test_gate_scripts.py",
     "test_release_upload.py",
 )
 
@@ -73,9 +76,13 @@ def test_sdist_contains_release_tooling_required_by_release_tests(tmp_path):
     with tarfile.open(archives[0], "r:gz") as archive:
         root = archive.getnames()[0].split("/", 1)[0]
         names = set(archive.getnames())
-        assert "%s/deploy.sh" % root in names
+        release_scripts = ("deploy.sh", "lint.sh", "test.sh")
+        for script_name in release_scripts:
+            assert "%s/%s" % (root, script_name) in names
         assert "%s/release_upload.py" % root in names
         assert "%s/tests/test_deploy_script.py" % root in names
+        assert "%s/tests/test_gate_scripts.py" % root in names
         assert "%s/tests/test_release_upload.py" % root in names
-        deploy_info = archive.getmember("%s/deploy.sh" % root)
-        assert deploy_info.mode & stat.S_IXUSR
+        for script_name in release_scripts:
+            script_info = archive.getmember("%s/%s" % (root, script_name))
+            assert script_info.mode & stat.S_IXUSR


### PR DESCRIPTION
Closes #202.

## What changed

- resolve Python once in the documented order: explicit PYTHON, active VIRTUAL_ENV, repository .venv, then PATH python3
- export the absolute selected executable from deploy.sh
- run Ruff, xdist detection, pytest, build, Twine, and release upload through that interpreter
- include lint.sh and test.sh in the source distribution alongside their release regression tests

## Regression coverage

- conflicting explicit, active-venv, repository-venv, and PATH interpreters
- selected interpreter paths containing spaces
- missing, non-executable, and directory-valued explicit overrides fail closed
- hostile PATH traps prove lint, plugin detection, and pytest never fall back to bare commands
- both xdist-present and serial fallbacks
- source distribution contents and executable modes

Mutation checks confirmed the tests fail when interpreter export is removed or when Ruff, xdist detection, or pytest is changed back to a bare PATH command.

## Verification

- ./lint.sh
- ./test.sh: 293 passed, 6 pre-existing collection warnings, 94% coverage
- bash -n deploy.sh lint.sh test.sh