### PR TITLE
Verify release artifact bytes across PyPI retries

### DIFF
--- a/release_upload.py
+++ b/release_upload.py
@@ -13,6 +13,7 @@
 """Bounded, idempotent PyPI uploads for isovar releases."""
 
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -29,6 +30,8 @@ PYPI_JSON_BASE_URL = "https://pypi.org/pypi"
 DEFAULT_UPLOAD_TIMEOUT_SECONDS = 60.0
 DEFAULT_VERIFY_TIMEOUT_SECONDS = 30.0
 DEFAULT_VERIFY_POLL_SECONDS = 1.0
+SHA256_HEX_LENGTH = 64
+HASH_READ_SIZE_BYTES = 1024 * 1024
 
 
 class ReleaseUploadError(RuntimeError):
@@ -44,12 +47,37 @@ def expected_release_filenames(project, version):
     })
 
 
-def pypi_release_filenames(
+def sha256_file(path):
+    """Return the hexadecimal SHA-256 digest of a file."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as file_handle:
+        while True:
+            chunk = file_handle.read(HASH_READ_SIZE_BYTES)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validated_sha256(value, context):
+    """Normalize a SHA-256 value or fail closed on malformed metadata."""
+    if not isinstance(value, str):
+        raise ReleaseUploadError("Missing SHA-256 digest for %s" % context)
+    normalized = value.lower()
+    if (len(normalized) != SHA256_HEX_LENGTH or
+            any(character not in "0123456789abcdef" for character in normalized)):
+        raise ReleaseUploadError(
+            "Invalid SHA-256 digest for %s: %r" % (context, value)
+        )
+    return normalized
+
+
+def pypi_release_digests(
         project,
         version,
         json_base_url=PYPI_JSON_BASE_URL,
         request_timeout_seconds=10.0):
-    """Return the filenames published for one release in PyPI metadata."""
+    """Return a filename-to-SHA-256 map from PyPI release metadata."""
     url = "%s/%s/json?cache_bust=%s" % (
         json_base_url.rstrip("/"),
         quote(project, safe=""),
@@ -60,10 +88,47 @@ def pypi_release_filenames(
             payload = json.load(response)
     except HTTPError as error:
         if error.code == 404:
-            return frozenset()
+            return {}
         raise
+    if not isinstance(payload, dict):
+        raise ReleaseUploadError(
+            "Invalid PyPI release metadata for %s %s" % (project, version)
+        )
     releases = payload.get("releases", {})
-    return frozenset(item["filename"] for item in releases.get(version, ()))
+    if not isinstance(releases, dict):
+        raise ReleaseUploadError(
+            "Invalid PyPI release metadata for %s %s" % (project, version)
+        )
+    release_items = releases.get(version, ())
+    if not isinstance(release_items, (list, tuple)):
+        raise ReleaseUploadError(
+            "Invalid PyPI release metadata for %s %s" % (project, version)
+        )
+    result = {}
+    for item in release_items:
+        try:
+            filename = item["filename"]
+            sha256 = item["digests"]["sha256"]
+        except (KeyError, TypeError) as error:
+            raise ReleaseUploadError(
+                "Invalid PyPI artifact metadata for %s %s" % (project, version)
+            ) from error
+        if not isinstance(filename, str) or not filename:
+            raise ReleaseUploadError(
+                "Invalid PyPI artifact filename for %s %s: %r" % (
+                    project,
+                    version,
+                    filename,
+                )
+            )
+        sha256 = _validated_sha256(sha256, "PyPI artifact %s" % filename)
+        previous = result.get(filename)
+        if previous is not None and previous != sha256:
+            raise ReleaseUploadError(
+                "Conflicting PyPI SHA-256 digests for %s" % filename
+            )
+        result[filename] = sha256
+    return result
 
 
 def upload_distribution(
@@ -85,16 +150,44 @@ def upload_distribution(
     subprocess.run(command, check=True, timeout=timeout_seconds)
 
 
+def _published_file_matches(filename, expected_sha256, published_digests):
+    """Return true for an exact file, false if absent, and fail if different."""
+    expected_sha256 = _validated_sha256(
+        expected_sha256,
+        "local artifact %s" % filename,
+    )
+    if filename not in published_digests:
+        return False
+    actual_sha256 = _validated_sha256(
+        published_digests[filename],
+        "PyPI artifact %s" % filename,
+    )
+    if actual_sha256 != expected_sha256:
+        raise ReleaseUploadError(
+            "PyPI SHA-256 mismatch for %s: local=%s, pypi=%s" % (
+                filename,
+                expected_sha256,
+                actual_sha256,
+            )
+        )
+    return True
+
+
 def wait_for_release_file(
         filename,
-        fetch_release_filenames,
+        expected_sha256,
+        fetch_release_digests,
         timeout_seconds=DEFAULT_VERIFY_TIMEOUT_SECONDS,
         poll_seconds=DEFAULT_VERIFY_POLL_SECONDS):
-    """Poll release metadata until ``filename`` is visible or time expires."""
+    """Poll until ``filename`` is visible with the expected SHA-256 digest."""
     deadline = time.monotonic() + timeout_seconds
     while True:
         try:
-            if filename in set(fetch_release_filenames()):
+            published = dict(fetch_release_digests())
+            if _published_file_matches(
+                    filename,
+                    expected_sha256,
+                    published):
                 return True
         except (json.JSONDecodeError, OSError, URLError):
             # PyPI metadata can transiently fail while its release view is
@@ -106,10 +199,22 @@ def wait_for_release_file(
         time.sleep(min(poll_seconds, remaining))
 
 
+def _matching_release_filenames(expected_digests, published_digests):
+    """Return exact matches and fail if any expected filename has new bytes."""
+    matching = set()
+    for filename, expected_sha256 in expected_digests.items():
+        if _published_file_matches(
+                filename,
+                expected_sha256,
+                published_digests):
+            matching.add(filename)
+    return frozenset(matching)
+
+
 def publish_release(
         distribution_paths,
         expected_filenames,
-        fetch_release_filenames,
+        fetch_release_digests,
         upload_file,
         verify_timeout_seconds=DEFAULT_VERIFY_TIMEOUT_SECONDS,
         verify_poll_seconds=DEFAULT_VERIFY_POLL_SECONDS):
@@ -118,7 +223,7 @@ def publish_release(
     A timeout or nonzero Twine exit is ambiguous: the server may have accepted
     the immutable file before the client lost its response. Verify server state
     after every attempt and consider a file published only when its exact name
-    appears in PyPI metadata.
+    appears in PyPI metadata with the exact local SHA-256 digest.
     """
     distribution_paths = tuple(distribution_paths)
     paths_by_name = {
@@ -136,10 +241,24 @@ def publish_release(
             )
         )
 
-    published = frozenset(fetch_release_filenames())
+    try:
+        expected_digests = {
+            filename: sha256_file(paths_by_name[filename])
+            for filename in sorted(expected)
+        }
+    except OSError as error:
+        raise ReleaseUploadError(
+            "Could not hash release artifact: %s" % error
+        ) from error
+
     for filename in sorted(expected):
-        if filename in published:
-            print("Already published: %s" % filename)
+        published_digests = dict(fetch_release_digests())
+        matching = _matching_release_filenames(
+            expected_digests,
+            published_digests,
+        )
+        if filename in matching:
+            print("Already published with matching SHA-256: %s" % filename)
             continue
 
         upload_error = None
@@ -150,7 +269,8 @@ def publish_release(
 
         if not wait_for_release_file(
                 filename,
-                fetch_release_filenames,
+                expected_digests[filename],
+                fetch_release_digests,
                 timeout_seconds=verify_timeout_seconds,
                 poll_seconds=verify_poll_seconds):
             message = "PyPI did not publish %s after the upload attempt" % filename
@@ -161,15 +281,18 @@ def publish_release(
             print("Reconciled ambiguous upload from PyPI state: %s" % filename)
         else:
             print("Published: %s" % filename)
-        published = frozenset(fetch_release_filenames())
 
-    published = frozenset(fetch_release_filenames())
-    missing = expected - published
+    published_digests = dict(fetch_release_digests())
+    matching = _matching_release_filenames(
+        expected_digests,
+        published_digests,
+    )
+    missing = expected - matching
     if missing:
         raise ReleaseUploadError(
             "PyPI release is missing expected files: %s" % sorted(missing)
         )
-    return published
+    return published_digests
 
 
 def main(argv=None):
@@ -200,8 +323,8 @@ def main(argv=None):
 
     expected = expected_release_filenames(args.project, args.version)
 
-    def fetch_release_filenames():
-        return pypi_release_filenames(
+    def fetch_release_digests():
+        return pypi_release_digests(
             args.project,
             args.version,
             json_base_url=args.json_base_url,
@@ -218,13 +341,13 @@ def main(argv=None):
     published = publish_release(
         args.distributions,
         expected_filenames=expected,
-        fetch_release_filenames=fetch_release_filenames,
+        fetch_release_digests=fetch_release_digests,
         upload_file=upload_file,
         verify_timeout_seconds=args.verify_timeout_seconds,
     )
     print(
         "Verified PyPI release files: %s" %
-        ", ".join(sorted(expected & published))
+        ", ".join(sorted(expected & set(published)))
     )
     return 0
 

--- a/tests/test_release_upload.py
+++ b/tests/test_release_upload.py
@@ -24,51 +24,87 @@ from release_upload import (
     ReleaseUploadError,
     expected_release_filenames,
     main,
-    pypi_release_filenames,
+    pypi_release_digests,
     publish_release,
+    sha256_file,
     upload_distribution,
     wait_for_release_file,
 )
 
 
 EXPECTED = expected_release_filenames("isovar", "1.7.3")
+WHEEL = "isovar-1.7.3-py3-none-any.whl"
+SDIST = "isovar-1.7.3.tar.gz"
 PATHS = tuple(Path("dist") / filename for filename in EXPECTED)
+VALID_SHA256 = "a" * 64
+OTHER_SHA256 = "b" * 64
+
+
+@pytest.fixture
+def release_files(tmp_path):
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    contents = {
+        WHEEL: b"wheel bytes",
+        SDIST: b"source distribution bytes",
+    }
+    paths = []
+    for filename in sorted(EXPECTED):
+        path = dist_dir / filename
+        path.write_bytes(contents[filename])
+        paths.append(path)
+    return tuple(paths)
+
+
+def _local_digests(paths):
+    return {path.name: sha256_file(path) for path in paths}
 
 
 def test_expected_release_filenames_are_exact_wheel_and_sdist():
-    assert EXPECTED == {
-        "isovar-1.7.3-py3-none-any.whl",
-        "isovar-1.7.3.tar.gz",
-    }
+    assert EXPECTED == {WHEEL, SDIST}
 
 
-def test_pypi_release_filenames_reads_project_release_map(monkeypatch):
+def test_sha256_file_reads_the_complete_file_in_chunks(tmp_path, monkeypatch):
+    path = tmp_path / "artifact"
+    path.write_bytes(b"abc")
+    monkeypatch.setattr(release_upload, "HASH_READ_SIZE_BYTES", 2)
+
+    assert sha256_file(path) == (
+        "ba7816bf8f01cfea414140de5dae2223"
+        "b00361a396177a9cb410ff61f20015ad"
+    )
+
+
+def test_pypi_release_digests_reads_project_release_map(monkeypatch):
     observed = {}
 
     def open_url(url, timeout):
         observed.update(url=url, timeout=timeout)
         return io.BytesIO(json.dumps({
             "releases": {
-                "1.7.3": [{"filename": "isovar-1.7.3.tar.gz"}],
+                "1.7.3": [{
+                    "filename": SDIST,
+                    "digests": {"sha256": VALID_SHA256.upper()},
+                }],
             },
         }).encode("utf-8"))
 
     monkeypatch.setattr(release_upload, "urlopen", open_url)
     monkeypatch.setattr(release_upload, "token_hex", lambda length: "fresh-token")
 
-    assert pypi_release_filenames(
+    assert pypi_release_digests(
         "isovar",
         "1.7.3",
         json_base_url="https://packages.example/pypi/",
         request_timeout_seconds=7,
-    ) == {"isovar-1.7.3.tar.gz"}
+    ) == {SDIST: VALID_SHA256}
     assert observed == {
         "url": "https://packages.example/pypi/isovar/json?cache_bust=fresh-token",
         "timeout": 7,
     }
 
 
-def test_pypi_release_filenames_uses_fresh_url_for_each_poll(monkeypatch):
+def test_pypi_release_digests_uses_fresh_url_for_each_poll(monkeypatch):
     urls = []
     tokens = iter(["first-token", "second-token"])
 
@@ -79,8 +115,8 @@ def test_pypi_release_filenames_uses_fresh_url_for_each_poll(monkeypatch):
     monkeypatch.setattr(release_upload, "urlopen", open_url)
     monkeypatch.setattr(release_upload, "token_hex", lambda length: next(tokens))
 
-    pypi_release_filenames("isovar", "1.7.3")
-    pypi_release_filenames("isovar", "1.7.3")
+    pypi_release_digests("isovar", "1.7.3")
+    pypi_release_digests("isovar", "1.7.3")
 
     assert urls == [
         "https://pypi.org/pypi/isovar/json?cache_bust=first-token",
@@ -88,12 +124,101 @@ def test_pypi_release_filenames_uses_fresh_url_for_each_poll(monkeypatch):
     ]
 
 
-def test_pypi_release_filenames_treats_missing_project_as_empty(monkeypatch):
+def test_pypi_release_digests_treats_missing_project_as_empty(monkeypatch):
     def open_url(url, timeout):
         raise HTTPError(url, 404, "Not Found", {}, None)
 
     monkeypatch.setattr(release_upload, "urlopen", open_url)
-    assert pypi_release_filenames("isovar", "1.7.3") == frozenset()
+    assert pypi_release_digests("isovar", "1.7.3") == {}
+
+
+@pytest.mark.parametrize("payload", [
+    None,
+    [],
+    {"releases": None},
+    {"releases": []},
+    {"releases": {"1.7.3": {}}},
+])
+def test_pypi_release_digests_rejects_invalid_release_metadata(
+        monkeypatch,
+        payload):
+    monkeypatch.setattr(
+        release_upload,
+        "urlopen",
+        lambda url, timeout: io.BytesIO(json.dumps(payload).encode("utf-8")),
+    )
+
+    with pytest.raises(ReleaseUploadError, match="Invalid PyPI release metadata"):
+        pypi_release_digests("isovar", "1.7.3")
+
+
+@pytest.mark.parametrize("item", [
+    None,
+    {},
+    {"filename": SDIST},
+    {"filename": SDIST, "digests": {}},
+])
+def test_pypi_release_digests_rejects_missing_metadata(monkeypatch, item):
+    monkeypatch.setattr(
+        release_upload,
+        "urlopen",
+        lambda url, timeout: io.BytesIO(json.dumps({
+            "releases": {"1.7.3": [item]},
+        }).encode("utf-8")),
+    )
+
+    with pytest.raises(ReleaseUploadError, match="Invalid PyPI artifact metadata"):
+        pypi_release_digests("isovar", "1.7.3")
+
+
+@pytest.mark.parametrize("digest", [None, "", "not-a-digest", "g" * 64])
+def test_pypi_release_digests_rejects_invalid_sha256(monkeypatch, digest):
+    monkeypatch.setattr(
+        release_upload,
+        "urlopen",
+        lambda url, timeout: io.BytesIO(json.dumps({
+            "releases": {"1.7.3": [{
+                "filename": SDIST,
+                "digests": {"sha256": digest},
+            }]},
+        }).encode("utf-8")),
+    )
+
+    with pytest.raises(ReleaseUploadError, match="SHA-256 digest"):
+        pypi_release_digests("isovar", "1.7.3")
+
+
+@pytest.mark.parametrize("filename", [None, ""])
+def test_pypi_release_digests_rejects_invalid_filename(monkeypatch, filename):
+    monkeypatch.setattr(
+        release_upload,
+        "urlopen",
+        lambda url, timeout: io.BytesIO(json.dumps({
+            "releases": {"1.7.3": [{
+                "filename": filename,
+                "digests": {"sha256": VALID_SHA256},
+            }]},
+        }).encode("utf-8")),
+    )
+
+    with pytest.raises(ReleaseUploadError, match="artifact filename"):
+        pypi_release_digests("isovar", "1.7.3")
+
+
+def test_pypi_release_digests_rejects_conflicting_duplicate(monkeypatch):
+    monkeypatch.setattr(
+        release_upload,
+        "urlopen",
+        lambda url, timeout: io.BytesIO(json.dumps({
+            "releases": {"1.7.3": [
+                {"filename": SDIST, "digests": {"sha256": VALID_SHA256}},
+                {"filename": SDIST, "digests": {"sha256": OTHER_SHA256}},
+            ]},
+        }).encode("utf-8")),
+    )
+
+    with pytest.raises(ReleaseUploadError, match="Conflicting PyPI SHA-256"):
+        pypi_release_digests("isovar", "1.7.3")
 
 
 def test_upload_distribution_is_bounded_and_disables_progress(monkeypatch):
@@ -123,11 +248,12 @@ def test_upload_distribution_is_bounded_and_disables_progress(monkeypatch):
     }
 
 
-def test_wait_for_release_file_observes_eventual_metadata():
-    responses = iter([set(), {"isovar-1.7.3.tar.gz"}])
+def test_wait_for_release_file_observes_eventual_matching_digest():
+    responses = iter([{}, {SDIST: VALID_SHA256}])
 
     assert wait_for_release_file(
-        "isovar-1.7.3.tar.gz",
+        SDIST,
+        VALID_SHA256,
         lambda: next(responses),
         timeout_seconds=1,
         poll_seconds=0,
@@ -137,21 +263,33 @@ def test_wait_for_release_file_observes_eventual_metadata():
 def test_wait_for_release_file_retries_transient_metadata_error():
     responses = iter([
         URLError("temporary metadata failure"),
-        {"isovar-1.7.3.tar.gz"},
+        {SDIST: VALID_SHA256},
     ])
 
-    def fetch_release_filenames():
+    def fetch_release_digests():
         response = next(responses)
         if isinstance(response, Exception):
             raise response
         return response
 
     assert wait_for_release_file(
-        "isovar-1.7.3.tar.gz",
-        fetch_release_filenames,
+        SDIST,
+        VALID_SHA256,
+        fetch_release_digests,
         timeout_seconds=1,
         poll_seconds=0,
     )
+
+
+def test_wait_for_release_file_rejects_same_name_with_different_digest():
+    with pytest.raises(ReleaseUploadError, match="SHA-256 mismatch"):
+        wait_for_release_file(
+            SDIST,
+            VALID_SHA256,
+            lambda: {SDIST: OTHER_SHA256},
+            timeout_seconds=1,
+            poll_seconds=0,
+        )
 
 
 @pytest.mark.parametrize(
@@ -167,86 +305,188 @@ def test_wait_for_release_file_retries_transient_metadata_error():
         ),
     ],
 )
-def test_ambiguous_failure_after_server_acceptance_is_reconciled(upload_error):
-    published = set()
-
-    def fetch_release_filenames():
-        return published
+def test_ambiguous_failure_is_reconciled_only_by_matching_digest(
+        release_files,
+        upload_error):
+    local_digests = _local_digests(release_files)
+    published = {}
 
     def upload_file(path):
-        published.add(path.name)
+        published[path.name] = local_digests[path.name]
         raise upload_error
 
     result = publish_release(
-        PATHS,
+        release_files,
         expected_filenames=EXPECTED,
-        fetch_release_filenames=fetch_release_filenames,
+        fetch_release_digests=lambda: published,
         upload_file=upload_file,
         verify_timeout_seconds=0,
     )
 
-    assert EXPECTED <= result
+    assert result == local_digests
 
 
-def test_partial_release_uploads_only_missing_file_and_retry_is_safe():
-    wheel = "isovar-1.7.3-py3-none-any.whl"
-    sdist = "isovar-1.7.3.tar.gz"
-    published = {wheel}
-    uploaded = []
-
-    def fetch_release_filenames():
-        return published
+def test_ambiguous_failure_with_different_server_bytes_fails_hard(release_files):
+    published = {}
 
     def upload_file(path):
-        uploaded.append(path.name)
-        published.add(path.name)
+        published[path.name] = OTHER_SHA256
+        raise subprocess.TimeoutExpired(["twine", "upload", path], timeout=60)
 
-    for _ in range(2):
+    with pytest.raises(ReleaseUploadError, match="SHA-256 mismatch"):
         publish_release(
-            PATHS,
+            release_files,
             expected_filenames=EXPECTED,
-            fetch_release_filenames=fetch_release_filenames,
+            fetch_release_digests=lambda: published,
             upload_file=upload_file,
             verify_timeout_seconds=0,
         )
 
-    assert uploaded == [sdist]
+
+def test_partial_release_uploads_only_missing_file_and_retry_is_safe(
+        release_files):
+    local_digests = _local_digests(release_files)
+    published = {WHEEL: local_digests[WHEEL]}
+    uploaded = []
+
+    def upload_file(path):
+        uploaded.append(path.name)
+        published[path.name] = local_digests[path.name]
+
+    for _ in range(2):
+        publish_release(
+            release_files,
+            expected_filenames=EXPECTED,
+            fetch_release_digests=lambda: published,
+            upload_file=upload_file,
+            verify_timeout_seconds=0,
+        )
+
+    assert uploaded == [SDIST]
 
 
-def test_failed_upload_without_server_artifact_fails_hard():
+@pytest.mark.parametrize("conflicting_filename", [WHEEL, SDIST])
+def test_existing_digest_mismatch_aborts_before_any_upload(
+        release_files,
+        conflicting_filename):
+    published = {conflicting_filename: OTHER_SHA256}
+    uploaded = []
+
+    with pytest.raises(ReleaseUploadError, match="SHA-256 mismatch"):
+        publish_release(
+            release_files,
+            expected_filenames=EXPECTED,
+            fetch_release_digests=lambda: published,
+            upload_file=lambda path: uploaded.append(path),
+            verify_timeout_seconds=0,
+        )
+
+    assert uploaded == []
+
+
+def test_failed_upload_without_server_artifact_fails_hard(release_files):
     def upload_file(path):
         raise subprocess.TimeoutExpired(["twine", "upload", path], timeout=60)
 
     with pytest.raises(ReleaseUploadError, match="did not publish"):
         publish_release(
-            PATHS,
+            release_files,
             expected_filenames=EXPECTED,
-            fetch_release_filenames=frozenset,
+            fetch_release_digests=dict,
             upload_file=upload_file,
             verify_timeout_seconds=0,
         )
 
 
-def test_unexpected_distribution_set_is_rejected_before_upload():
+def test_successful_upload_with_different_server_bytes_fails_hard(release_files):
+    published = {}
+
+    def upload_file(path):
+        published[path.name] = OTHER_SHA256
+
+    with pytest.raises(ReleaseUploadError, match="SHA-256 mismatch"):
+        publish_release(
+            release_files,
+            expected_filenames=EXPECTED,
+            fetch_release_digests=lambda: published,
+            upload_file=upload_file,
+            verify_timeout_seconds=0,
+        )
+
+
+def test_final_verification_rejects_digest_changed_after_exact_matches(
+        release_files):
+    local_digests = _local_digests(release_files)
+    changed_digests = dict(local_digests)
+    changed_digests[SDIST] = OTHER_SHA256
+    responses = iter([
+        local_digests,
+        local_digests,
+        changed_digests,
+    ])
+
+    with pytest.raises(ReleaseUploadError, match="SHA-256 mismatch"):
+        publish_release(
+            release_files,
+            expected_filenames=EXPECTED,
+            fetch_release_digests=lambda: next(responses),
+            upload_file=lambda path: pytest.fail("unexpected upload"),
+        )
+
+
+def test_final_verification_rejects_missing_artifact(release_files):
+    local_digests = _local_digests(release_files)
+    responses = iter([
+        local_digests,
+        local_digests,
+        {WHEEL: local_digests[WHEEL]},
+    ])
+
+    with pytest.raises(ReleaseUploadError, match="missing expected files"):
+        publish_release(
+            release_files,
+            expected_filenames=EXPECTED,
+            fetch_release_digests=lambda: next(responses),
+            upload_file=lambda path: pytest.fail("unexpected upload"),
+        )
+
+
+def test_unexpected_distribution_set_is_rejected_before_hash_or_upload():
     with pytest.raises(ReleaseUploadError, match="do not match"):
         publish_release(
             ["dist/isovar-1.7.3.tar.gz"],
             expected_filenames=EXPECTED,
-            fetch_release_filenames=frozenset,
+            fetch_release_digests=dict,
             upload_file=lambda path: None,
         )
 
 
-def test_duplicate_distribution_basename_is_rejected_before_upload():
+def test_duplicate_distribution_basename_is_rejected_before_hash_or_upload():
     paths = list(PATHS) + [Path("other") / next(iter(EXPECTED))]
 
     with pytest.raises(ReleaseUploadError, match="do not match"):
         publish_release(
             paths,
             expected_filenames=EXPECTED,
-            fetch_release_filenames=frozenset,
+            fetch_release_digests=dict,
             upload_file=lambda path: None,
         )
+
+
+def test_missing_distribution_file_is_rejected_before_network_or_upload():
+    fetched = []
+    uploaded = []
+
+    with pytest.raises(ReleaseUploadError, match="Could not hash"):
+        publish_release(
+            PATHS,
+            expected_filenames=EXPECTED,
+            fetch_release_digests=lambda: fetched.append(True),
+            upload_file=lambda path: uploaded.append(path),
+        )
+
+    assert fetched == []
+    assert uploaded == []
 
 
 def test_main_passes_exact_artifact_contract_to_publisher(monkeypatch, capsys):
@@ -256,8 +496,9 @@ def test_main_passes_exact_artifact_contract_to_publisher(monkeypatch, capsys):
         observed.update(
             distribution_paths=tuple(distribution_paths),
             expected_filenames=kwargs["expected_filenames"],
+            fetch_release_digests=kwargs["fetch_release_digests"],
         )
-        return EXPECTED
+        return {filename: VALID_SHA256 for filename in EXPECTED}
 
     monkeypatch.setattr(release_upload, "publish_release", publish_release_call)
 
@@ -266,8 +507,7 @@ def test_main_passes_exact_artifact_contract_to_publisher(monkeypatch, capsys):
         "--version", "1.7.3",
         *[str(path) for path in PATHS],
     ]) == 0
-    assert observed == {
-        "distribution_paths": tuple(str(path) for path in PATHS),
-        "expected_filenames": EXPECTED,
-    }
+    assert observed["distribution_paths"] == tuple(str(path) for path in PATHS)
+    assert observed["expected_filenames"] == EXPECTED
+    assert callable(observed["fetch_release_digests"])
     assert "Verified PyPI release files" in capsys.readouterr().out


### PR DESCRIPTION
Closes #199.

## What changed

- read each PyPI release artifact SHA-256 instead of discarding it
- hash local wheels and source distributions with bounded-memory streaming reads
- skip an existing artifact only when its filename and digest both match
- reconcile successful or ambiguous uploads only after the matching digest is visible
- validate every already-published expected artifact before uploading either file and verify the complete digest set at the end
- fail closed on malformed PyPI metadata, unreadable local files, missing artifacts, or digest conflicts

A retry remains automatic when rebuilt artifacts are byte-identical. A non-reproducible rebuild now aborts safely and requires a new version; durable preservation of original build artifacts is intentionally separate from this integrity fix.

## Regression coverage

The test matrix covers exact and mismatched existing files, both artifact orderings, partial releases, upload timeout and nonzero-exit reconciliation, post-upload mismatches, final-state drift, missing files, malformed metadata, invalid digests, duplicate metadata, and streaming hashing. Restoring filename-only acceptance makes the regression tests fail.

## Verification

- ./lint.sh
- ./test.sh: 318 passed, 6 pre-existing collection warnings, 94% coverage
- live read-only check: PyPI 1.7.7 metadata digests exactly matched both local 1.7.7 artifacts