### PR TITLE
Fix mutation intervals, shared RNA support, and assembly determinism

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.7.8"
+__version__ = "1.7.9"
 
 
 from .allele_read import AlleleRead

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -40,6 +40,11 @@ logger = get_logger(__name__)
 DEFAULT_ASSEMBLY_KMER_SIZE = 15
 
 
+def _sequence_key(sequence):
+    """Canonical identity, including the position of the variant."""
+    return sequence.prefix, sequence.alt, sequence.suffix
+
+
 def _sequence_kmers(sequence, k):
     return {
         sequence[i:i + k]
@@ -106,6 +111,11 @@ def greedy_merge_helper(
     Returns a list of merged VariantSequence objects, and True if any
     were successfully merged.
     """
+    # Canonical indices make equal-score tie breaks independent of read/input
+    # order. Merge identical candidates first so splitting their read sets
+    # between duplicate entries cannot change their support score.
+    variant_sequences = sorted(
+        merge_identical_sequences(variant_sequences), key=_sequence_key)
     candidates = []
     for i, j in _greedy_merge_candidate_pairs(
             variant_sequences,
@@ -122,7 +132,7 @@ def greedy_merge_helper(
     if not candidates:
         return list(variant_sequences), False
 
-    # largest overlap first, then most reads, then indices for determinism
+    # Largest overlap first, then most reads, then canonical sequence indices.
     candidates.sort(key=lambda c: (-c[0], -c[1], c[2], c[3]))
 
     used = set()
@@ -132,7 +142,7 @@ def greedy_merge_helper(
             continue
         used.add(i)
         used.add(j)
-        combined_key = (combined.prefix, combined.alt, combined.suffix)
+        combined_key = _sequence_key(combined)
         if combined_key in merged_variant_sequences:
             existing = merged_variant_sequences[combined_key]
             combined = combined.add_reads(existing.reads)
@@ -167,7 +177,7 @@ def greedy_merge(
 
     def preserve_candidates(candidates):
         for candidate in candidates:
-            key = (candidate.prefix, candidate.alt, candidate.suffix)
+            key = _sequence_key(candidate)
             if key in intermediate_candidates:
                 candidate = intermediate_candidates[key].add_reads(
                     candidate.reads)
@@ -183,7 +193,7 @@ def greedy_merge(
         if preserve_intermediate_candidates and merged_any:
             preserve_candidates(variant_sequences)
     if preserve_intermediate_candidates:
-        return list(intermediate_candidates.values())
+        return sorted(intermediate_candidates.values(), key=_sequence_key)
     return variant_sequences
 
 
@@ -198,6 +208,7 @@ def collapse_substrings(variant_sequences):
 
     Returns a (potentially shorter) list without any contained subsequences.
     """
+    variant_sequences = merge_identical_sequences(variant_sequences)
     if len(variant_sequences) <= 1:
         # if we don't have at least two VariantSequences then just
         # return your input
@@ -207,10 +218,11 @@ def collapse_substrings(variant_sequences):
     # they absorb from substring VariantSequences
     extra_reads_from_substrings = defaultdict(set)
     result_list = []
-    # sort by longest to shortest total length
+    # Longest first, with content-based ties so an ambiguous contained read
+    # is always assigned to the same parent regardless of input order.
     for short_variant_sequence in sorted(
             variant_sequences,
-            key=lambda seq: -len(seq)):
+            key=lambda seq: (-len(seq), _sequence_key(seq))):
         found_superstring = False
         for long_variant_sequence in result_list:
             if long_variant_sequence.contains(short_variant_sequence):
@@ -239,11 +251,7 @@ def merge_identical_sequences(variant_sequences):
     """
     sequences_by_parts = {}
     for variant_sequence in variant_sequences:
-        key = (
-            variant_sequence.prefix,
-            variant_sequence.alt,
-            variant_sequence.suffix,
-        )
+        key = _sequence_key(variant_sequence)
         if key in sequences_by_parts:
             variant_sequence = sequences_by_parts[key].add_reads(
                 variant_sequence.reads)

--- a/isovar/translation_helpers.py
+++ b/isovar/translation_helpers.py
@@ -16,7 +16,6 @@ Helper functions used for creating translating a variant's cDNA sequence
 into a particular reading frame.
 """
 
-import math
 
 def find_mutant_amino_acid_interval(
         cdna_sequence,
@@ -72,7 +71,6 @@ def find_mutant_amino_acid_interval(
 
     frame_of_variant_nucleotides = n_coding_nucleotides_before_variant % 3
     frameshift = abs(n_ref - n_alt) % 3 != 0
-    indel = n_ref != n_alt
 
     variant_aa_interval_start = n_complete_prefix_codons
 
@@ -83,31 +81,12 @@ def find_mutant_amino_acid_interval(
         # TODO: what if the first k amino acids are synonymous with the reference sequence?
         variant_aa_interval_end = n_amino_acids
     else:
-        n_alt_codons = int(math.ceil(n_alt / 3.0))
-        if indel:
-            # We need to adjust the number of affected codons by whether the
-            # variant is aligned with codon boundaries, since in-frame indels
-            # may still be split across multiple codons.
-            #
-            # Example of in-frame deletion of 3 nucleotides which leaves
-            # 0 variant codons in the sequence (interval = 1:1)
-            #   ref = CCC|AAA|GGG|TTT
-            #   alt = CCC|GGG|TTT
-            #
-            # Example of in-frame deletion of 3 nucleotides which leaves
-            # 1 variant codon in the sequence (interval = 1:2)
-            #   ref = CCC|AAA|GGG|TTT
-            #   alt = CCC|AGG|TTT
-            #
-            # Example of in-frame insertion of 3 nucleotides which
-            # yields two variant codons:
-            #   ref = CCC|AAA|GGG|TTT
-            #   alt = CTT|TCC|AAA|GGG|TTT
-            extra_affected_codon = int(frame_of_variant_nucleotides != 0)
-            variant_aa_interval_end = (
-                variant_aa_interval_start + n_alt_codons + extra_affected_codon)
-        else:
-            # if the variant is a simple substitution then it only affects
-            # as many codons as are in the alternate sequence
-            variant_aa_interval_end = variant_aa_interval_start + n_alt_codons
+        # Count codons from the start of the first affected codon, not from
+        # the first alternate base. Substitutions can cross codon boundaries
+        # too (ATG|AAA -> ATT|CCA changes two amino acids for GAA -> TCC).
+        # This also handles in-frame delins without overcounting a codon.
+        # For pure deletions, a codon-aligned junction has zero width; an
+        # off-boundary junction joins partial codons into one affected codon.
+        n_affected_codons = (frame_of_variant_nucleotides + n_alt + 2) // 3
+        variant_aa_interval_end = variant_aa_interval_start + n_affected_codons
     return variant_aa_interval_start, variant_aa_interval_end, frameshift

--- a/isovar/variant_sequence_creator.py
+++ b/isovar/variant_sequence_creator.py
@@ -30,8 +30,8 @@ logger = get_logger(__name__)
 class VariantSequenceCreator(object):
     """
     Assemble AlleleReads into candidate VariantSequence objects based on
-    overlap, retaining independently supported contained candidates for
-    reference matching.
+    overlap, retaining contained candidates with their compatible read
+    support for reference matching.
     """
     def __init__(
             self,
@@ -156,9 +156,10 @@ class VariantSequenceCreator(object):
             logger.info("After coverage filtering: 0 variant sequences")
             return []
 
-        # sort VariantSequence objects by decreasing order of supporting read
-        # counts
-        variant_sequences.sort(key=lambda vs: -len(vs.reads))
+        # Sort by decreasing read support, with content-based ties even when
+        # overlap assembly is disabled.
+        variant_sequences.sort(key=lambda vs: (
+            -len(vs.reads), vs.prefix, vs.alt, vs.suffix))
         return variant_sequences
 
     def sequences_from_alt_reads_generator(self, variant_and_reads_generator):

--- a/isovar/variant_sequence_helpers.py
+++ b/isovar/variant_sequence_helpers.py
@@ -141,12 +141,47 @@ def filter_variant_sequences_by_length(
     return nonempty_variant_sequences
 
 
+def _variant_sequences_with_shared_read_support(variant_sequences, read_groups):
+    """Assign compatible original reads to each retained candidate.
+
+    Compatibility is checked against the reads themselves, not transitively
+    through other candidates: a short core can match two conflicting longer
+    branches without either branch supporting the other. Overhangs outside a
+    candidate are irrelevant, and coverage still uses each read's real bounds.
+    No sequence is extended or invented here. Reads may support more than one
+    alternative; downstream aggregation deduplicates them by set union.
+    """
+    result = []
+    for sequence in variant_sequences:
+        supporting_reads = set()
+        for (prefix, alt, suffix), group in read_groups.items():
+            overlap_size = (
+                min(len(prefix), len(sequence.prefix)) + len(alt)
+                + min(len(suffix), len(sequence.suffix)))
+            if (alt == sequence.alt
+                    and overlap_size > 0
+                    and (prefix.endswith(sequence.prefix) or sequence.prefix.endswith(prefix))
+                    and (suffix.startswith(sequence.suffix) or sequence.suffix.startswith(suffix))):
+                supporting_reads.update(group)
+        if supporting_reads == sequence.reads:
+            result.append(sequence)
+        else:
+            result.append(VariantSequence(
+                prefix=sequence.prefix,
+                alt=sequence.alt,
+                suffix=sequence.suffix,
+                reads=supporting_reads))
+    return result
+
+
 def trim_variant_sequences(variant_sequences, min_variant_sequence_coverage):
     """
     Trim VariantSequences to desired coverage and combine exact duplicates.
 
     Contained but non-identical candidates remain separate because reference
-    compatibility is not known at this stage.
+    compatibility is not known at this stage. Reconcile their compatible read
+    support before applying the coverage threshold, including when overlap
+    assembly is disabled.
 
     Parameters
     ----------
@@ -157,6 +192,15 @@ def trim_variant_sequences(variant_sequences, min_variant_sequence_coverage):
     Returns list of VariantSequence
     """
     n_total = len(variant_sequences)
+    variant_sequences = merge_identical_sequences(
+        sequence for sequence in variant_sequences if len(sequence) > 0)
+    reads = {read for sequence in variant_sequences for read in sequence.reads}
+    # Compare once per distinct read sequence, rather than once per fragment
+    # or per appearance in the retained assembly history. Keep this original
+    # pool even when some of its candidates are discarded below.
+    read_groups = group_unique_sequences(reads)
+    variant_sequences = _variant_sequences_with_shared_read_support(
+        variant_sequences, read_groups)
     # when no base of a sequence has sufficient coverage, trim_by_coverage
     # returns an empty sequence which still carries every one of the original
     # reads. Those sequences are useless downstream and their read counts are
@@ -172,6 +216,11 @@ def trim_variant_sequences(variant_sequences, min_variant_sequence_coverage):
     ]
     trimmed_variant_sequences = merge_identical_sequences(
         trimmed_variant_sequences)
+    # Removing low-coverage overhangs can make previously conflicting reads
+    # compatible. Recount against the original pool without extending the
+    # trimmed sequences or introducing another round of candidate generation.
+    trimmed_variant_sequences = _variant_sequences_with_shared_read_support(
+        trimmed_variant_sequences, read_groups)
     n_after_trimming = len(trimmed_variant_sequences)
     logger.info(
         "Kept %d/%d variant sequences after read coverage trimming to >=%dx",

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -14,6 +14,8 @@ import random
 from itertools import permutations
 from time import time
 
+import pytest
+
 from isovar.read_collector import ReadCollector
 from isovar.variant_sequence import VariantSequence
 from isovar.variant_sequence_helpers import initial_variant_sequences_from_reads
@@ -468,6 +470,55 @@ def test_greedy_merge_deterministic_across_input_orders():
         assert result_all_reads == reference_all_reads, \
             "Trial %d: different reads from shuffled input.\nRef: %s\nGot: %s" % (
                 trial, reference_all_reads, result_all_reads)
+
+
+@pytest.mark.parametrize("assemble", [greedy_merge, iterative_overlap_assembly])
+def test_equal_score_competing_merges_are_deterministic(assemble):
+    candidates = [
+        VariantSequence("AAA", "C", "", {"left"}),
+        VariantSequence("AA", "C", "GG", {"right_g"}),
+        VariantSequence("AA", "C", "TT", {"right_t"}),
+    ]
+    expected = None
+    for ordered in permutations(candidates):
+        result = assemble(ordered, min_overlap_size=1)
+        observed = [(s.prefix, s.alt, s.suffix, s.reads) for s in result]
+        if expected is None:
+            expected = observed
+        assert observed == expected
+    assert any(s[0] == "AAA" and len(s[2]) == 2 for s in expected)
+
+
+def test_equal_length_substring_parents_have_deterministic_support():
+    candidates = [
+        VariantSequence("AAA", "C", "GGG", {"left"}),
+        VariantSequence("TAA", "C", "GGG", {"right"}),
+        VariantSequence("AA", "C", "GG", {"core"}),
+        # Duplicate triples must also pool their support deterministically.
+        VariantSequence("AAA", "C", "GGG", {"left_duplicate"}),
+    ]
+    expected = None
+    for ordered in permutations(candidates):
+        result = collapse_substrings(ordered)
+        observed = [(s.prefix, s.alt, s.suffix, s.reads) for s in result]
+        if expected is None:
+            expected = observed
+        assert observed == expected
+    assert len(expected) == 2
+    assert set().union(*(s[3] for s in expected)) == {
+        "left", "right", "core", "left_duplicate"}
+
+
+def test_duplicate_candidate_read_partitions_do_not_change_merge_choice():
+    left = VariantSequence("AAA", "C", "", {"left"})
+    right_g = VariantSequence("AA", "C", "GG", {"g1", "g2"})
+    right_t = VariantSequence("AA", "C", "TT", {"t1", "t2"})
+    expected = greedy_merge([left, right_g, right_t], min_overlap_size=1)
+    split = [left, right_t,
+             VariantSequence("AA", "C", "GG", {"g1"}),
+             VariantSequence("AA", "C", "GG", {"g2"})]
+    for ordered in permutations(split):
+        assert greedy_merge(ordered, min_overlap_size=1) == expected
 
 
 def test_greedy_merge_helper_skips_impossible_pairs(monkeypatch):

--- a/tests/test_translation_helpers.py
+++ b/tests/test_translation_helpers.py
@@ -1,0 +1,57 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from isovar.translation_helpers import find_mutant_amino_acid_interval
+
+
+@pytest.mark.parametrize("codon_offset", [0, 1, 7])
+@pytest.mark.parametrize("frame", range(3))
+@pytest.mark.parametrize("n_ref,n_alt", [
+    (n_ref, n_alt)
+    for n_ref in range(10)
+    for n_alt in range(10)
+    if n_ref or n_alt
+])
+def test_mutation_interval_covers_affected_codons(codon_offset, frame, n_ref, n_alt):
+    """#208: enumerate codons, independently of the interval arithmetic.
+
+    Cover substitutions, insertions, deletions and delins at every codon
+    position, including incomplete leading codons and untranslated prefixes.
+    """
+    coding_prefix_length = 12 + frame
+    variant_start = codon_offset + coding_prefix_length
+    cdna = "T" * codon_offset + "A" * coding_prefix_length + "C" * n_alt + "G" * 36
+    n_amino_acids = (len(cdna) - codon_offset) // 3
+    frameshift = (n_alt - n_ref) % 3 != 0
+
+    if frameshift:
+        expected_end = n_amino_acids
+    else:
+        affected_codons = {
+            (coding_prefix_length + i) // 3 for i in range(n_alt)
+        }
+        # An in-frame deletion either joins two partial codons into one
+        # affected codon, or leaves a zero-width junction between codons.
+        if not n_alt and frame:
+            affected_codons.add(coding_prefix_length // 3)
+        expected_end = max(affected_codons) + 1 if affected_codons else 4
+
+    assert find_mutant_amino_acid_interval(
+        cdna_sequence=cdna,
+        cdna_first_codon_offset=codon_offset,
+        cdna_variant_start_offset=variant_start,
+        cdna_variant_end_offset=variant_start + n_alt,
+        n_ref=n_ref,
+        n_amino_acids=n_amino_acids,
+    ) == (4, expected_end, frameshift)

--- a/tests/test_translation_regressions.py
+++ b/tests/test_translation_regressions.py
@@ -1,0 +1,128 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from itertools import permutations
+
+import pytest
+from varcode import Variant
+
+from isovar.allele_read import AlleleRead
+from isovar.dna import reverse_complement_dna
+from isovar.protein_sequence_creator import ProteinSequenceCreator
+from isovar.reference_context import ReferenceContext
+from isovar.variant_sequence_creator import VariantSequenceCreator
+
+
+def _genomic_allele(cdna, strand):
+    return cdna if strand == "+" else reverse_complement_dna(cdna)
+
+
+def _read(prefix, alt, suffix, name, strand):
+    if strand == "-":
+        prefix, alt, suffix = (
+            reverse_complement_dna(suffix),
+            reverse_complement_dna(alt),
+            reverse_complement_dna(prefix),
+        )
+    return AlleleRead(prefix=prefix, allele=alt, suffix=suffix, name=name)
+
+
+def _context(variant, strand, prefix, suffix):
+    return ReferenceContext(
+        strand=strand,
+        sequence_before_variant_locus=prefix,
+        sequence_at_variant_locus=_genomic_allele(variant.ref, strand),
+        sequence_after_variant_locus=suffix,
+        offset_to_first_complete_codon=0,
+        contains_start_codon=False,
+        overlaps_start_codon=False,
+        contains_five_prime_utr=False,
+        amino_acids_before_variant="",
+        variant=variant,
+        transcripts=(),
+    )
+
+
+@pytest.mark.parametrize("strand", ["+", "-"])
+@pytest.mark.parametrize("assembly", [False, True])
+def test_multibase_substitution_marks_both_changed_amino_acids(strand, assembly):
+    """#208: RNA-backed translation must expose both changes to vaxrank."""
+    variant = Variant("1", 100, _genomic_allele("GAA", strand),
+                      _genomic_allele("TCC", strand), "GRCh38")
+    prefix, suffix = "AAA" * 4 + "AT", "AGGG"
+    reads = [_read(prefix, "TCC", suffix, str(i), strand) for i in range(2)]
+    sequences = VariantSequenceCreator(
+        variant_sequence_assembly=assembly).reads_to_variant_sequences(variant, reads)
+    context = _context(variant, strand, prefix, suffix)
+    translation, = ProteinSequenceCreator().all_pairs_translations(sequences, [context])
+
+    # NCBI standard code: ATG|AAA -> ATT|CCA, i.e. MK -> IP.
+    # https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi#SG1
+    assert translation.amino_acids == "KKKKIPG"
+    assert (translation.mutation_start_idx, translation.mutation_end_idx) == (4, 6)
+    assert translation.contains_mutation
+    assert not translation.frameshift
+
+
+@pytest.mark.parametrize("strand", ["+", "-"])
+@pytest.mark.parametrize("assembly", [False, True])
+def test_nested_single_read_candidates_keep_shared_support(strand, assembly):
+    """#209: retained candidates need support, not just their original reads."""
+    variant = Variant("1", 100, _genomic_allele("G", strand),
+                      _genomic_allele("C", strand), "GRCh38")
+    prefixes = [p + "A" * 12 for p in (
+        "", "GGG", "CCCGGG", "TTTCCCGGG", "GGGTTTCCCGGG")]
+    reads = [_read(prefix, "C", "A" * 30, str(i), strand)
+             for i, prefix in enumerate(prefixes)]
+    context = _context(variant, strand, "A" * 24, "A" * 30)
+    creator = VariantSequenceCreator(variant_sequence_assembly=assembly)
+    protein_creator = ProteinSequenceCreator()
+
+    for ordered_reads in (reads, list(reversed(reads))):
+        sequences = creator.reads_to_variant_sequences(variant, ordered_reads)
+        core, = [sequence for sequence in sequences
+                 if (sequence.prefix if strand == "+" else
+                     reverse_complement_dna(sequence.suffix)) == "A" * 12]
+        assert core.reads == frozenset(reads)
+        assert core.min_coverage() == 5
+        translations = protein_creator.all_pairs_translations(sequences, [context])
+        assert translations
+        assert {translation.amino_acids for translation in translations} == {"KKKKQKKKKKKKKK"}
+
+
+@pytest.mark.parametrize("strand", ["+", "-"])
+def test_competing_assembly_branches_translate_independently_of_read_order(strand):
+    """#210: equal merge scores must not choose a peptide by BAM order."""
+    variant = Variant("1", 100, _genomic_allele("G", strand),
+                      _genomic_allele("C", strand), "GRCh38")
+    groups = [
+        [_read(prefix, "C", suffix, "%d_%d" % (i, j), strand) for j in range(2)]
+        for i, (prefix, suffix) in enumerate([
+            ("A" * 12, "G" * 21),
+            ("A" * 9, "G" * 21 + "A" * 6),
+            ("A" * 9, "G" * 21 + "T" * 6),
+        ])
+    ]
+    context = _context(variant, strand, "A" * 12, "G" * 21 + "A" * 6)
+    creator = VariantSequenceCreator(variant_sequence_assembly=True)
+    protein_creator = ProteinSequenceCreator()
+    expected = None
+    for order in permutations(groups):
+        reads = [read for group in order for read in group]
+        sequences = creator.reads_to_variant_sequences(variant, reads)
+        translations = protein_creator.all_pairs_translations(sequences, [context])
+        observed = sorted(
+            (t.amino_acids, tuple(sorted(r.name for r in t.reads))) for t in translations)
+        assert any(len(amino_acids) == 13 for amino_acids, _ in observed)
+        if expected is None:
+            expected = observed
+        assert observed == expected

--- a/tests/test_variant_orf.py
+++ b/tests/test_variant_orf.py
@@ -24,6 +24,7 @@ from isovar.reference_context import ReferenceContext
 from isovar.allele_read import AlleleRead
 from isovar.dna import reverse_complement_dna
 from isovar.protein_sequence_creator import ProteinSequenceCreator
+from isovar.protein_sequence_helpers import group_equivalent_translations
 from isovar.variant_sequence_creator import VariantSequenceCreator
 from isovar.variant_sequence_helpers import filter_variant_sequences
 
@@ -315,10 +316,20 @@ def test_nested_assemblies_reach_reference_matching_independently(
         compatible_sequence = reverse_complement_dna("AAA")
     eq_(observed_candidates,
         set(genomic_prefixes if strand == "+" else genomic_suffixes))
-    eq_(len(translations), 1)
-    translated_sequence = translations[0].untrimmed_variant_sequence
+    # Shared support also allows two longer candidates to trim down to the
+    # same compatible core. The original shortest candidate must still reach
+    # translation independently, and grouping must not multiply its support.
+    eq_(len(translations), 3)
+    translated_sequence, = [
+        translation.untrimmed_variant_sequence for translation in translations
+        if (translation.untrimmed_variant_sequence.prefix if strand == "+" else
+            translation.untrimmed_variant_sequence.suffix) == compatible_sequence
+    ]
     eq_(translated_sequence.prefix if strand == "+" else translated_sequence.suffix,
         compatible_sequence)
+    protein_sequence, = group_equivalent_translations(translations)
+    eq_(protein_sequence.num_supporting_fragments, 8)
+    eq_(protein_sequence.num_supporting_reads, 8)
 
 
 def test_protein_sequence_creator_translates_coding_deletion():

--- a/tests/test_variant_sequence_support.py
+++ b/tests/test_variant_sequence_support.py
@@ -1,0 +1,164 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from itertools import permutations
+import random
+
+import pytest
+
+from isovar.allele_read import AlleleRead
+from isovar.variant_sequence import VariantSequence
+from isovar.variant_sequence_creator import VariantSequenceCreator
+from isovar.variant_sequence_helpers import trim_variant_sequences
+
+
+def _sequence(prefix, alt, suffix, name):
+    return VariantSequence(prefix, alt, suffix, [
+        AlleleRead(prefix, alt, suffix, name=name)])
+
+
+@pytest.mark.parametrize("alt", ["C", "", "CTG"])
+def test_support_is_shared_without_transferring_conflicting_reads(alt):
+    left = _sequence("AAA", alt, "GGG", "left")
+    right = _sequence("TAA", alt, "GGG", "right")
+    core = _sequence("AA", alt, "GG", "core")
+    suffix_conflict = _sequence("AAA", alt, "TGG", "suffix_conflict")
+    allele_conflict = _sequence("AAA", "T", "GGG", "allele_conflict")
+    # The core can carry reads with incompatible overhangs outside its own
+    # bounds. Those reads must not leak into either longer branch by way of it.
+    core = core.add_reads(left.reads | right.reads)
+    expected = {
+        ("AAA", alt, "GGG"): {"left", "core"},
+        ("TAA", alt, "GGG"): {"right", "core"},
+        ("AA", alt, "GG"): {"left", "right", "core"},
+        ("AAA", alt, "TGG"): {"suffix_conflict"},
+        ("AAA", "T", "GGG"): {"allele_conflict"},
+    }
+    for ordered in permutations([left, right, core, suffix_conflict, allele_conflict]):
+        observed = trim_variant_sequences(list(ordered), min_variant_sequence_coverage=1)
+        assert {(s.prefix, s.alt, s.suffix): s.read_names for s in observed} == expected
+
+
+def test_identical_candidates_pool_support_before_coverage_filtering():
+    first = _sequence("AA", "C", "GG", "first")
+    second = _sequence("AA", "C", "GG", "second")
+    result, = trim_variant_sequences([first, second, first], min_variant_sequence_coverage=2)
+    assert result.read_names == {"first", "second"}
+    assert result.coverage().tolist() == [2] * 5
+
+
+def test_shared_support_respects_actual_read_bounds_and_invalidates_coverage_cache():
+    left = _sequence("AAAA", "C", "GG", "left")
+    right = _sequence("AA", "C", "GGGG", "right")
+    assert left.min_coverage() == right.min_coverage() == 1
+
+    # No new flanking sequence is assembled here: only their common 2x core
+    # survives, even though both candidates have two compatible reads.
+    result, = trim_variant_sequences([left, right], min_variant_sequence_coverage=2)
+    assert (result.prefix, result.alt, result.suffix) == ("AA", "C", "GG")
+    assert result.read_names == {"left", "right"}
+    assert result.coverage().tolist() == [2] * 5
+    assert left.min_coverage() == right.min_coverage() == 1
+
+
+def test_newly_trimmed_core_recovers_reads_from_a_discarded_conflicting_candidate():
+    left = _sequence("AAAA", "C", "GG", "left")
+    right = _sequence("AA", "C", "GGGG", "right")
+    # Conflicts with the left prefix and right suffix, but not with the 2x
+    # core produced by trimming them. Its own candidate is discarded at 1x.
+    outside_conflicts = _sequence("TAA", "C", "GGT", "outside_conflicts")
+    for ordered in permutations([left, right, outside_conflicts]):
+        result, = trim_variant_sequences(list(ordered), min_variant_sequence_coverage=2)
+        assert (result.prefix, result.alt, result.suffix) == ("AA", "C", "GG")
+        assert result.read_names == {"left", "right", "outside_conflicts"}
+        assert result.coverage().tolist() == [3] * 5
+
+
+def test_empty_candidates_neither_survive_nor_donate_support():
+    real = _sequence("AA", "", "GG", "real")
+    empty = VariantSequence("", "", "", [
+        AlleleRead("AA", "", "GG", name="empty_%d" % i) for i in range(4)])
+    assert trim_variant_sequences([empty], min_variant_sequence_coverage=1) == []
+    assert trim_variant_sequences([real, empty], min_variant_sequence_coverage=2) == []
+
+
+def test_identical_full_strings_at_different_variant_positions_do_not_share_support():
+    first = _sequence("T", "C", "CG", "first")
+    second = _sequence("TC", "C", "G", "second")
+    assert first.sequence == second.sequence
+    assert trim_variant_sequences([first, second], min_variant_sequence_coverage=2) == []
+
+
+def test_deletion_reads_without_any_shared_bases_do_not_inflate_support():
+    left = _sequence("AA", "", "", "left")
+    right = _sequence("", "", "GG", "right")
+    observed = trim_variant_sequences([left, right], min_variant_sequence_coverage=1)
+    assert set(observed) == {left, right}
+
+
+@pytest.mark.parametrize("assembly", [False, True])
+def test_creator_tied_support_is_order_independent_without_requiring_a_merge(assembly):
+    candidates = [_sequence("AAA", "C", suffix, "%s_%d" % (suffix, i))
+                  for suffix in ("GGG", "TTT") for i in range(2)]
+    reads = [next(iter(candidate.reads)) for candidate in candidates]
+    creator = VariantSequenceCreator(variant_sequence_assembly=assembly)
+    expected = None
+    for ordered in permutations(reads):
+        # This method uses the reads, not the variant metadata.
+        observed = creator.reads_to_variant_sequences(None, iter(ordered))
+        assert len(observed) == 2
+        if expected is None:
+            expected = observed
+        assert observed == expected
+
+
+def test_shared_support_matches_independent_base_coordinate_oracle():
+    """Exercise anchored matching against a per-base oracle, not string tests."""
+    rng = random.Random(209)
+
+    def coordinates(prefix, alt, suffix):
+        return dict(enumerate(prefix + alt + suffix, start=-len(prefix)))
+
+    for _ in range(20):
+        reads = [AlleleRead(
+            prefix="".join(rng.choices("ACGT", k=rng.randrange(7))),
+            allele=rng.choice(["C", "", "CTG"]),
+            suffix="".join(rng.choices("ACGT", k=rng.randrange(7))),
+            name=str(i)) for i in range(30)]
+        reads = [read for read in reads if len(read)]
+        candidates = [VariantSequence(r.prefix, r.allele, r.suffix, [r]) for r in reads]
+        for read in reads:
+            prefix = read.prefix[rng.randrange(len(read.prefix) + 1):]
+            suffix = read.suffix[:rng.randrange(len(read.suffix) + 1)]
+            if prefix or read.allele or suffix:
+                candidates.append(VariantSequence(prefix, read.allele, suffix, [read]))
+
+        expected = {}
+        for candidate in candidates:
+            bases = coordinates(candidate.prefix, candidate.alt, candidate.suffix)
+            supporting_reads = set()
+            coverage = dict.fromkeys(bases, 0)
+            for read in reads:
+                read_bases = coordinates(read.prefix, read.allele, read.suffix)
+                common_positions = bases.keys() & read_bases.keys()
+                if (read.allele == candidate.alt and common_positions
+                        and all(bases[p] == read_bases[p] for p in common_positions)):
+                    supporting_reads.add(read)
+                    for position in common_positions:
+                        coverage[position] += 1
+            expected[(candidate.prefix, candidate.alt, candidate.suffix)] = (
+                supporting_reads, list(coverage.values()))
+
+        for ordered in (candidates, list(reversed(candidates))):
+            results = trim_variant_sequences(ordered, min_variant_sequence_coverage=1)
+            assert {(s.prefix, s.alt, s.suffix): (s.reads, s.coverage().tolist())
+                    for s in results} == expected

--- a/tests/test_variant_sequences.py
+++ b/tests/test_variant_sequences.py
@@ -46,12 +46,19 @@ def test_sequence_counts_snv():
     variant_sequences = variant_sequence_creator.reads_to_variant_sequences(
         variant=variant,
         reads=variant_reads)
-    assert len(variant_sequences) == 1
+    # Fourteen compatible read-spanned candidates have >=2x shared coverage.
+    # Previously only the longest exact-read group survived: the shorter
+    # candidates lost the other reads which also supported their bases.
+    assert len(variant_sequences) == 14
+    longest = max(variant_sequences, key=len)
+    eq_(len(longest.prefix), 30)
+    eq_(len(longest.suffix), 30)
     for variant_sequence in variant_sequences:
         print(variant_sequence)
         eq_(variant_sequence.alt, alt)
-        eq_(len(variant_sequence.prefix), 30)
-        eq_(len(variant_sequence.suffix), 30)
+        assert longest.contains(variant_sequence)
+        assert variant_sequence.min_coverage() >= 2
+        eq_(len(variant_sequence.reads), 19)
         eq_(
             variant_sequence.prefix + variant_sequence.alt + variant_sequence.suffix,
             variant_sequence.sequence)
@@ -476,7 +483,10 @@ def test_trim_variant_sequences_preserves_supported_substrings():
         [longer, shorter],
         min_variant_sequence_coverage=2)
 
-    eq_(set(trimmed), {longer, shorter})
+    eq_(set(trimmed), {
+        longer.add_reads(shorter.reads),
+        shorter.add_reads(longer.reads),
+    })
 
 
 def test_trim_variant_sequences_merges_only_exact_trimmed_duplicates():


### PR DESCRIPTION
## Summary

Closes #208. Closes #209. Closes #210.

- Compute affected codons from both the alternate length and starting codon position. Fix MNV under-counting and in-frame delins over-counting while retaining deletion-junction and frameshift behavior.
- Assign original reads directly to every compatible retained candidate before coverage filtering, then recount after trimming. Do not propagate conflicting overhangs through shared cores, count disjoint deletion flanks as support, or donate reads from degenerate candidates.
- Canonicalize duplicate candidates, equal-score merge ties, equal-length substring parents, and tied non-assembly output ordering.
- Bump isovar to 1.7.9 without API changes.

## Verification

- ./lint.sh: passed.
- TEST_SH_MAX=4 ./test.sh: 1,235 passed, with four pre-existing test-collection warnings.
- 891 codon-grid cases cover reference/alternate lengths 0–9, every codon position, and three coding offsets. The new focused regressions produced 100 failures against the unfixed code.
- Both-strand translation regressions, assembly on/off, input permutations, duplicate partitions, incompatible branches, deletion edge cases, and an independent per-base support/coverage oracle.
- Six existing vaxrank RNA-backed integration tests passed. Explicit vaxrank handoff preserves both mutated residues IP in KKKKIPG with interval [4, 6).
- A 1,000-candidate / 20,000-read support stress check completed in 0.70 seconds with exact counts and coverage checked.

Primary codon reference: https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi#SG1

## Compatibility notes

Corrected shared support intentionally retains more valid shorter candidates. Existing fixture tests now assert their bases, coverage, and read support rather than requiring their accidental loss. Equivalent translations still deduplicate fragment/read support. Greedy assembly remains a deterministic heuristic, not exhaustive haplotype enumeration.