### PR TITLE
Preserve required reference context for long alternate alleles

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.7.9"
+__version__ = "1.7.10"
 
 
 from .allele_read import AlleleRead

--- a/isovar/allele_read_helpers.py
+++ b/isovar/allele_read_helpers.py
@@ -76,15 +76,23 @@ def group_unique_sequences(
     Given a list of AlleleRead objects, extracts all unique
     (prefix, allele, suffix) sequences and associate each with a list
     of reads that contained that sequence.
+
+    Flank limits are non-negative lengths: None leaves a flank unbounded,
+    while zero removes it. Trimming always retains the bases nearest the
+    variant and never modifies the allele itself.
     """
+    for name, limit in (("max_prefix_size", max_prefix_size),
+                        ("max_suffix_size", max_suffix_size)):
+        if limit is not None and limit < 0:
+            raise ValueError("%s must be non-negative or None" % name)
     groups = defaultdict(set)
     for r in allele_reads:
         prefix = r.prefix
         allele = r.allele
         suffix = r.suffix
-        if max_prefix_size and len(prefix) > max_prefix_size:
-            prefix = prefix[-max_prefix_size:]
-        if max_suffix_size and len(suffix) > max_suffix_size:
+        if max_prefix_size is not None and len(prefix) > max_prefix_size:
+            prefix = prefix[len(prefix) - max_prefix_size:]
+        if max_suffix_size is not None and len(suffix) > max_suffix_size:
             suffix = suffix[:max_suffix_size]
         key = (prefix, allele, suffix)
         groups[key].add(r)

--- a/isovar/protein_sequence_creator.py
+++ b/isovar/protein_sequence_creator.py
@@ -108,7 +108,8 @@ class ProteinSequenceCreator(ValueObject):
             min_variant_sequence_coverage=self.min_variant_sequence_coverage,
             preferred_sequence_length=self._cdna_sequence_length,
             variant_sequence_assembly=self.variant_sequence_assembly,
-            min_assembly_overlap_size=self.min_assembly_overlap_size)
+            min_assembly_overlap_size=self.min_assembly_overlap_size,
+            min_flanking_sequence_length=self.min_transcript_prefix_length)
 
         self.max_protein_sequences_per_variant = max_protein_sequences_per_variant
 
@@ -281,7 +282,7 @@ class ProteinSequenceCreator(ValueObject):
 
         reference_contexts = reference_contexts_for_variant(
             variant,
-            context_size=self._cdna_sequence_length,
+            context_size=max(self._cdna_sequence_length, self.min_transcript_prefix_length),
             transcript_id_whitelist=transcript_id_whitelist)
 
         if len(reference_contexts) == 0:

--- a/isovar/variant_orf_helpers.py
+++ b/isovar/variant_orf_helpers.py
@@ -40,8 +40,8 @@ def match_variant_sequence_to_reference_context(
         metadata.
 
     min_transcript_prefix_length : int
-        Minimum number of nucleotides we try to match against a reference
-        transcript.
+        Minimum shared prefix length after RNA and reference context are
+        normalized to the same length in transcript orientation.
 
     max_transcript_mismatches : int
         Maximum number of nucleotide differences between reference transcript
@@ -64,16 +64,18 @@ def match_variant_sequence_to_reference_context(
         # check the reverse-complemented prefix if the reference context is
         # on the negative strand since variant sequence is aligned to
         # genomic DNA (positive strand)
-        variant_sequence_too_short = (
-            (reference_context.strand == "+" and
-                len(variant_sequence.prefix) < min_transcript_prefix_length) or
-            (reference_context.strand == "-" and
-                len(variant_sequence.suffix) < min_transcript_prefix_length)
-        )
-        if variant_sequence_too_short:
+        variant_prefix_length = len(
+            variant_sequence.suffix if reference_context.strand == "-"
+            else variant_sequence.prefix)
+        # VariantORF trims both prefixes to their common length. Checking only
+        # the RNA length would let short reference contexts bypass the minimum.
+        shared_prefix_length = min(
+            variant_prefix_length,
+            len(reference_context.sequence_before_variant_locus))
+        if shared_prefix_length < min_transcript_prefix_length:
             logger.info(
-                "Prefix of variant sequence %s shorter than min allowed %d (iter=%d)",
-                variant_sequence,
+                "Shared RNA/reference prefix length %d shorter than min allowed %d (iter=%d)",
+                shared_prefix_length,
                 min_transcript_prefix_length,
                 i + 1)
             return None

--- a/isovar/variant_sequence_creator.py
+++ b/isovar/variant_sequence_creator.py
@@ -38,7 +38,8 @@ class VariantSequenceCreator(object):
             min_variant_sequence_coverage=MIN_VARIANT_SEQUENCE_COVERAGE,
             preferred_sequence_length=VARIANT_SEQUENCE_LENGTH,
             variant_sequence_assembly=VARIANT_SEQUENCE_ASSEMBLY,
-            min_assembly_overlap_size=MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE):
+            min_assembly_overlap_size=MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE,
+            min_flanking_sequence_length=0):
         """
         Parameters
         ----------
@@ -47,8 +48,9 @@ class VariantSequenceCreator(object):
             variant cDNA sequence
 
         preferred_sequence_length : int
-            Total number of nucleotides in the assembled sequences, including
-            variant nucleotides.
+            Preferred total number of nucleotides, including the alternate
+            allele. The allele and required flanking context may exceed this
+            budget; neither is discarded to meet a preferred output length.
 
         variant_sequence_assembly : bool
             Construct variant sequences by merging overlapping reads. If False
@@ -58,11 +60,22 @@ class VariantSequenceCreator(object):
             Minimum number of nucleotides shared by two sequences before they
             can be merged into a single VariantSequence object.
 
+        min_flanking_sequence_length : int
+            Minimum desired context on each side of the variant, retained
+            when available even if the preferred total length is exceeded.
+            Both genomic sides are needed since transcript strand is not yet
+            known. This does not pad reads or invent missing sequence.
+
         """
+        if preferred_sequence_length < 0:
+            raise ValueError("preferred_sequence_length must be non-negative")
+        if min_flanking_sequence_length < 0:
+            raise ValueError("min_flanking_sequence_length must be non-negative")
         self.min_variant_sequence_coverage = min_variant_sequence_coverage
         self.preferred_sequence_length = preferred_sequence_length
         self.variant_sequence_assembly = variant_sequence_assembly
         self.min_assembly_overlap_size = min_assembly_overlap_size
+        self.min_flanking_sequence_length = min_flanking_sequence_length
 
     def reads_to_variant_sequences(
             self,
@@ -96,7 +109,12 @@ class VariantSequenceCreator(object):
         # is half the desired length (minus the number of variant nucleotides)
         n_alt_nucleotides = len(alt_seq)
 
-        n_surrounding_nucleotides = self.preferred_sequence_length - n_alt_nucleotides
+        # The alternate allele may consume or exceed the preferred budget.
+        # Still retain the context needed for reference matching on either
+        # strand, and never pass negative flank limits to sequence slicing.
+        n_surrounding_nucleotides = max(
+            self.preferred_sequence_length - n_alt_nucleotides,
+            2 * self.min_flanking_sequence_length)
         max_nucleotides_after_variant = n_surrounding_nucleotides // 2
 
         # if the number of nucleotides we need isn't divisible by 2 then
@@ -124,7 +142,7 @@ class VariantSequenceCreator(object):
             # (whichever is smaller)
             min_overlap_size = min(
                 self.min_assembly_overlap_size,
-                n_surrounding_nucleotides // 2)
+                max(1, n_surrounding_nucleotides // 2))
             variant_sequences = iterative_overlap_assembly(
                 variant_sequences,
                 min_overlap_size=min_overlap_size,

--- a/tests/test_read_helpers.py
+++ b/tests/test_read_helpers.py
@@ -15,6 +15,7 @@ from isovar.allele_read import AlleleRead
 from isovar.allele_read_helpers import group_unique_sequences, get_single_allele_from_reads
 
 from varcode import Variant
+import pytest
 
 from .common import eq_
 from .testing_helpers import load_bam
@@ -76,3 +77,28 @@ def test_get_single_allele_from_reads_empty_raises():
     import pytest
     with pytest.raises(ValueError):
         get_single_allele_from_reads([])
+
+
+@pytest.mark.parametrize("prefix_limit", [None, 0, 1, 2, 3, 4, 10])
+@pytest.mark.parametrize("suffix_limit", [None, 0, 1, 2, 3, 4, 10])
+@pytest.mark.parametrize("alt", ["", "C", "CTG"])
+def test_flank_limits_are_explicit_and_anchor_preserving(prefix_limit, suffix_limit, alt):
+    read = AlleleRead(prefix="ACG", allele=alt, suffix="TGA", name="read")
+    groups = group_unique_sequences([read], prefix_limit, suffix_limit)
+    expected_prefix = "".join(
+        base for i, base in enumerate(read.prefix)
+        if prefix_limit is None or len(read.prefix) - i <= prefix_limit)
+    expected_suffix = "".join(
+        base for i, base in enumerate(read.suffix)
+        if suffix_limit is None or i < suffix_limit)
+    assert groups == {(expected_prefix, alt, expected_suffix): {read}}
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"max_prefix_size": -1}, {"max_suffix_size": -1},
+    {"max_prefix_size": -20}, {"max_suffix_size": -20},
+])
+@pytest.mark.parametrize("reads", [[], [AlleleRead("ACG", "C", "TGA", "read")]])
+def test_negative_flank_limits_are_rejected(kwargs, reads):
+    with pytest.raises(ValueError, match="non-negative"):
+        group_unique_sequences(reads, **kwargs)

--- a/tests/test_reference_context_limits.py
+++ b/tests/test_reference_context_limits.py
@@ -1,0 +1,164 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from varcode import Variant
+
+from isovar.protein_sequence_creator import ProteinSequenceCreator
+from isovar.variant_orf_helpers import match_variant_sequence_to_reference_context
+from isovar.variant_sequence import VariantSequence
+from isovar.variant_sequence_creator import VariantSequenceCreator
+
+from .test_translation_regressions import _context, _genomic_allele, _read
+
+
+@pytest.mark.parametrize("strand", ["+", "-"])
+@pytest.mark.parametrize("assembly", [False, True])
+@pytest.mark.parametrize("replacement", [False, True])
+@pytest.mark.parametrize("alt_length", [1, 3, 42, 43, 44, 45, 60, 61, 62, 63, 64, 65, 69, 90, 120])
+def test_long_alternates_retain_required_context(strand, assembly, replacement, alt_length, monkeypatch):
+    """#212: output-length preferences must not erase available ORF evidence."""
+    cdna_alt = "A" * alt_length
+    cdna_ref = "T" * alt_length if replacement else ""
+    variant = Variant("1", 100, _genomic_allele(cdna_ref, strand),
+                      _genomic_allele(cdna_alt, strand), "GRCh38")
+    prefix, suffix = "ACG" * 4, "G" * 30
+    reads = [_read(prefix, cdna_alt, suffix, str(i), strand) for i in range(3)]
+    context = _context(variant, strand, prefix, suffix)
+    monkeypatch.setattr(
+        "isovar.protein_sequence_creator.reference_contexts_for_variant",
+        lambda *args, **kwargs: [context])
+    creator = ProteinSequenceCreator(variant_sequence_assembly=assembly)
+
+    translation, = creator.translate_variant_reads(variant, reads)
+
+    assert translation.contains_mutation
+    assert 0 < len(translation.amino_acids) <= creator.protein_sequence_length
+    assert translation.reads == frozenset(reads)
+    assert translation.num_mismatches_before_variant == 0
+    assert len(translation.reference_cdna_sequence_before_variant) >= 10
+    orf = translation.variant_orf
+    assert orf.variant_cdna_interval_end - orf.variant_cdna_interval_start == alt_length
+    assert orf.cdna_sequence[orf.variant_cdna_interval_start:orf.variant_cdna_interval_end] == cdna_alt
+    if alt_length == 45:
+        # Prefix trimming leaves three complete ACG codons, followed by
+        # fifteen inserted/replaced AAA codons and the retained GGG suffix.
+        assert translation.amino_acids == "TTT" + "K" * 15 + "GG"
+        assert (translation.mutation_start_idx, translation.mutation_end_idx) == (3, 18)
+        assert not translation.frameshift
+
+
+@pytest.mark.parametrize("strand", ["+", "-"])
+@pytest.mark.parametrize("minimum", [3, 10, 25])
+@pytest.mark.parametrize("missing_context", [None, "rna", "reference"])
+def test_long_insertion_respects_custom_context_minimum(strand, minimum, missing_context, monkeypatch):
+    variant = Variant("1", 100, "", _genomic_allele("A" * 69, strand), "GRCh38")
+    rna_length = minimum - 1 if missing_context == "rna" else minimum + 2
+    reference_length = minimum - 1 if missing_context == "reference" else minimum + 2
+    reads = [_read("A" * rna_length, "A" * 69, "G" * 30, str(i), strand) for i in range(3)]
+    context = _context(variant, strand, "A" * reference_length, "G" * 30)
+    monkeypatch.setattr(
+        "isovar.protein_sequence_creator.reference_contexts_for_variant",
+        lambda *args, **kwargs: [context])
+    creator = ProteinSequenceCreator(min_transcript_prefix_length=minimum)
+    translations = creator.translate_variant_reads(variant, reads)
+
+    if missing_context:
+        assert translations == []
+    else:
+        translation, = translations
+        assert translation.contains_mutation
+        assert len(translation.reference_cdna_sequence_before_variant) >= minimum
+
+
+@pytest.mark.parametrize("strand", ["+", "-"])
+@pytest.mark.parametrize("rna_length", [0, 3, 9, 10, 11, 12])
+@pytest.mark.parametrize("reference_length", [0, 3, 9, 10, 11, 12])
+@pytest.mark.parametrize("minimum", [0, 3, 10])
+def test_match_minimum_uses_actual_shared_prefix(strand, rna_length, reference_length, minimum):
+    """#213: enforce the minimum on both sides of prefix normalization."""
+    variant = Variant("1", 100, _genomic_allele("G", strand),
+                      _genomic_allele("C", strand), "GRCh38")
+    read = _read("A" * rna_length, "C", "G" * 20, "read", strand)
+    sequence = VariantSequence(read.prefix, read.allele, read.suffix, [read])
+    context = _context(variant, strand, "A" * reference_length, "G" * 20)
+    orf = match_variant_sequence_to_reference_context(
+        sequence, context, min_transcript_prefix_length=minimum, max_transcript_mismatches=0)
+
+    shared_length = min(rna_length, reference_length)
+    if shared_length < minimum:
+        assert orf is None
+    else:
+        assert orf is not None
+        assert len(orf.reference_cdna_sequence_before_variant) == shared_length
+        assert orf.num_mismatches_before_variant == 0
+
+
+@pytest.mark.parametrize("strand", ["+", "-"])
+@pytest.mark.parametrize("core_length", [9, 10, 11])
+def test_match_minimum_is_rechecked_after_coverage_trimming(strand, core_length):
+    variant = Variant("1", 100, _genomic_allele("G", strand),
+                      _genomic_allele("C", strand), "GRCh38")
+    long_read = _read("C" + "A" * core_length, "C", "G" * 20, "long", strand)
+    short_read = _read("A" * core_length, "C", "G" * 20, "short", strand)
+    sequence = VariantSequence(long_read.prefix, long_read.allele, long_read.suffix, [long_read, short_read])
+    context = _context(variant, strand, "A" * 12, "G" * 20)
+
+    orf = match_variant_sequence_to_reference_context(
+        sequence, context, min_transcript_prefix_length=10,
+        max_transcript_mismatches=0, max_trimming_attempts=1)
+
+    if core_length < 10:
+        assert orf is None
+    else:
+        assert orf is not None
+        assert len(orf.reference_cdna_sequence_before_variant) == core_length
+
+
+def test_reference_lookup_budget_is_not_smaller_than_matching_minimum(monkeypatch):
+    seen = []
+
+    def lookup(variant, context_size, transcript_id_whitelist):
+        seen.append(context_size)
+        return []
+
+    monkeypatch.setattr("isovar.protein_sequence_creator.reference_contexts_for_variant", lookup)
+    variant = Variant("1", 100, "G", "C", "GRCh38")
+    read = _read("A" * 80, "C", "G" * 80, "read", "+")
+    ProteinSequenceCreator(min_transcript_prefix_length=70).translate_variant_reads(variant, [read])
+    assert len(seen) == 1
+    assert seen[0] >= 70
+
+
+@pytest.mark.parametrize("preferred_length", [0, 1, 3, 62, 63, 64])
+@pytest.mark.parametrize("minimum_flank", [0, 3, 10])
+def test_sequence_budget_never_creates_negative_flank_limits(preferred_length, minimum_flank):
+    creator = VariantSequenceCreator(
+        preferred_sequence_length=preferred_length,
+        min_flanking_sequence_length=minimum_flank,
+        variant_sequence_assembly=True)
+    reads = [_read("A" * 20, "C" * 63, "G" * 20, str(i), "+") for i in range(2)]
+    variant = Variant("1", 100, "", "C" * 63, "GRCh38")
+    sequence, = creator.reads_to_variant_sequences(variant, reads)
+    expected_prefix_length = 1 if preferred_length == 64 and minimum_flank == 0 else minimum_flank
+    assert sequence.prefix == "A" * expected_prefix_length
+    assert sequence.suffix == "G" * minimum_flank
+    assert sequence.alt == "C" * 63
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"preferred_sequence_length": -1},
+    {"min_flanking_sequence_length": -1},
+])
+def test_negative_sequence_budgets_are_rejected(kwargs):
+    with pytest.raises(ValueError, match="non-negative"):
+        VariantSequenceCreator(**kwargs)


### PR DESCRIPTION
## Summary

Closes #212.
Closes #213.

- Retain the configured reference-matching context on **both genomic flanks** when a long alternate allele consumes/exceeds the preferred cDNA length. The preferred output length is not permission to discard evidence required to establish an ORF.
- Enforce `min_transcript_prefix_length` on the actual shared RNA/reference prefix in transcript orientation, including every coverage-trimming retry.
- Make flank limits explicit: `None` is unbounded, zero retains zero bases, negative lengths raise `ValueError`. Avoid negative sequence budgets and accidental nonpositive derived assembly overlap.
- Ensure reference-context lookup requests at least the configured matching minimum.
- Bump isovar to **1.7.10**.

## Scope and compatibility

The new trailing `VariantSequenceCreator(min_flanking_sequence_length=0)` argument is optional; existing positional arguments remain unchanged. `ProteinSequenceCreator` supplies its existing matching minimum. Reads are never padded and insufficient real context still fails. The protein output-length cap and mismatch allowances are unchanged.

Base-quality filtering remains a separate follow-up in #8: its [reproduction and acceptance checklist](https://github.com/openvax/isovar/issues/8#issuecomment-5559393482) now distinguish MAPQ from variant-base quality and call out the substitution/insertion/deletion-anchor/mate policies. This PR does not change read-quality thresholds.

## Verification

Added 536 parameterized regression cases covering:
- insertions and multibase replacements from 1–120 bases, on both strands, assembly enabled/disabled;
- the exact peptide and mutation interval for the reported 45-base case;
- shared RNA/reference prefix lengths below, at, and above the configured minimum, including zero and coverage-trimming retries;
- custom context minima, genuinely missing RNA/reference context, and reference lookup budgets;
- zero, negative, unbounded, and boundary flank limits for deletion, SNV, and insertion alleles.

Local checks:
- `./lint.sh`: passed
- `TEST_SH_MAX=4 ./test.sh -q --tb=short --show-capture=no`: **1,771 passed**, 94% coverage
- downstream `vaxrank/tests/test_mutant_protein_sequence.py`: **6 passed**
- `git diff --check`: clean

Strand/codon-offset handling was checked against the [NCBI GenBank feature-table documentation](https://www.ncbi.nlm.nih.gov/genbank/feature_table/).